### PR TITLE
Fix: Ensure max_blank_confidence filter persists when saving observat…

### DIFF
--- a/wildmile/components/cameratrap/ImageAnnotation.js
+++ b/wildmile/components/cameratrap/ImageAnnotation.js
@@ -40,7 +40,7 @@ import styles from "styles/animalSelection.module.css";
 import { ObservationHistoryPopover } from "./ObservationHistory";
 import { SpeciesConsensusBadges } from "./SpeciesConsensusBadges";
 
-export function ImageAnnotation({ fetchNextImage }) {
+export function ImageAnnotation({ fetchNextImage, filters }) {
   const [currentImage, setCurrentImage] = useImage();
   const [selection, setSelection] = useSelection();
   const [animalCounts, setAnimalCounts] = useState({});
@@ -97,6 +97,7 @@ export function ImageAnnotation({ fetchNextImage }) {
         eventEnd: currentImage.timestamp,
         observationLevel: "media",
         observationType: "blank",
+        max_blank_confidence: filters?.maxConfBlank,
       });
     } else {
       if (selection.length > 0) {
@@ -114,6 +115,7 @@ export function ImageAnnotation({ fetchNextImage }) {
           eventEnd: currentImage.timestamp,
           observationLevel: "media",
           observationType: "animal",
+          max_blank_confidence: filters?.maxConfBlank,
         }));
       }
 
@@ -128,6 +130,7 @@ export function ImageAnnotation({ fetchNextImage }) {
           eventEnd: currentImage.timestamp,
           observationLevel: "media",
           observationType: "human",
+          max_blank_confidence: filters?.maxConfBlank,
         });
       }
 
@@ -142,6 +145,7 @@ export function ImageAnnotation({ fetchNextImage }) {
           eventEnd: currentImage.timestamp,
           observationLevel: "media",
           observationType: "vehicle",
+          max_blank_confidence: filters?.maxConfBlank,
         });
       }
     }

--- a/wildmile/components/cameratrap/ImageAnnotationPage.js
+++ b/wildmile/components/cameratrap/ImageAnnotationPage.js
@@ -23,18 +23,19 @@ import { IconArrowLeft, IconArrowRight } from "@tabler/icons-react";
 export const ImageAnnotationPage = ({ initialImageId }) => {
   const [currentImage, setCurrentImage] = useImage();
   const [deployments, setDeployments] = useState([]);
+  const [appliedFilters, setAppliedFilters] = useState({});
 
   // In your component, use initialImageId to fetch and set the initial image
   useEffect(() => {
     fetchDeployments();
     if (initialImageId) {
       // Fetch and set the specific image
-      fetchCamtrapImage({ selectedImageId: initialImageId });
+      fetchCamtrapImage({ ...appliedFilters, selectedImageId: initialImageId });
     } else {
       // Your existing logic for getting the next image
-      fetchCamtrapImage();
+      fetchCamtrapImage(appliedFilters);
     }
-  }, [initialImageId]);
+  }, [initialImageId, appliedFilters]);
 
   const fetchDeployments = async () => {
     try {
@@ -81,23 +82,29 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
   };
 
   const handleApplyFilters = (filters) => {
+    setAppliedFilters(filters);
     fetchCamtrapImage(filters);
   };
 
   const handleNavigateImage = (direction) => {
     if (currentImage) {
-      fetchCamtrapImage({ direction, currentImageId: currentImage._id });
+      fetchCamtrapImage({
+        ...appliedFilters,
+        direction,
+        currentImageId: currentImage._id,
+      });
     }
   };
 
   const fetchNextImage = async () => {
     if (currentImage) {
       await fetchCamtrapImage({
+        ...appliedFilters,
         direction: "next",
         currentImageId: currentImage._id,
       });
     } else {
-      await fetchCamtrapImage();
+      await fetchCamtrapImage(appliedFilters);
     }
   };
 
@@ -150,7 +157,10 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
           </Group>
 
           {/* <ScrollArea style={{ flex: 1 }} offsetScrollbars> */}
-          <ImageAnnotation fetchNextImage={fetchNextImage} />
+          <ImageAnnotation
+            fetchNextImage={fetchNextImage}
+            filters={appliedFilters}
+          />
           {/* </ScrollArea> */}
           {/* </Paper> */}
         </GridCol>


### PR DESCRIPTION
The `max_blank_confidence` filter (and other active filters) were not being applied to the `getCamtrapImage` request when fetching the next image after an observation was saved.

This commit addresses the issue by:

1. Modifying `components/cameratrap/ImageAnnotationPage.js`:
  - Ensures that `fetchNextImage`, `handleNavigateImage`, and the initial image loading logic correctly pass the `appliedFilters` (including `max_blank_confidence`) to the `fetchCamtrapImage` utility function.
  - This makes sure that any active filters in the UI are included as URL parameters in the API request when fetching images.


This ensures that the filter context is maintained when navigating to the next image after saving an observation.