### PR TITLE
Feature/new analytics tabs

### DIFF
--- a/wildmile/app/actions/CameratrapActions.js
+++ b/wildmile/app/actions/CameratrapActions.js
@@ -10,6 +10,7 @@ import { redirect } from "next/navigation";
 import { uploadFileToS3 } from "./UploadActions";
 import CameratrapMedia from "models/cameratrap/Media";
 import Observation from "models/cameratrap/Observation";
+import User from "models/User";
 
 import {
   S3Client,
@@ -427,4 +428,144 @@ if (typeof process !== "undefined" && exiftool) {
       console.error("Error closing exiftool:", e);
     }
   });
+}
+
+// Maintain original ocation of getStats as server action
+export async function getStats({ forceRefresh = false } = {}) {
+  await dbConnect();
+
+  try {
+    const totalImages = await CameratrapMedia.countDocuments();
+    const uniqueMediaIdsWithObservations = await Observation.distinct("mediaId");
+    const totalObservations = await Observation.countDocuments();
+
+    const validatedObservations = await Observation.aggregate([
+      { $group: { _id: { mediaId: "$mediaId", scientificName: "$scientificName" }, count: { $sum: 1 } } },
+      { $match: { count: { $gte: 2 } } },
+      { $group: { _id: "$_id.mediaId" } },
+      { $count: "count" },
+    ]);
+
+    const totalVolunteers = await Observation.distinct("creator");
+
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    const newImages30Days = await CameratrapMedia.countDocuments({ createdAt: { $gte: thirtyDaysAgo } });
+
+    const topCreators = await Observation.aggregate([
+      { $group: { _id: "$creator", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 5 },
+      { $lookup: { from: "users", localField: "_id", foreignField: "_id", as: "userInfo" } },
+      { $project: {
+        id: { $toString: "$_id" }, // Convert ObjectId to string
+        name: {
+          $ifNull: [
+            { $arrayElemAt: ["$userInfo.profile.name", 0] },
+            { $arrayElemAt: ["$userInfo.email", 0] },
+            "Unknown User",
+          ],
+        },
+        count: 1,
+        _id: 0 // Exclude _id from results
+      } },
+    ]);
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    const [mostActive7Days] = await Observation.aggregate([
+      { $match: { createdAt: { $gte: sevenDaysAgo } } },
+      { $group: { _id: "$creator", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 1 },
+      { $lookup: { from: "users", localField: "_id", foreignField: "_id", as: "userInfo" } },
+      { $project: {
+        id: { $toString: "$_id" }, // Convert ObjectId to string
+        name: {
+          $ifNull: [
+            { $arrayElemAt: ["$userInfo.profile.name", 0] },
+            { $arrayElemAt: ["$userInfo.email", 0] },
+            "Unknown User",
+          ],
+        },
+        count: 1,
+        _id: 0 // Exclude _id from results
+      } },
+    ]);
+
+    const [mostBlanks] = await Observation.aggregate([
+      { $match: { observationType: "blank" } },
+      { $group: { _id: "$creator", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 1 },
+      { $lookup: { from: "users", localField: "_id", foreignField: "_id", as: "userInfo" } },
+      { $project: {
+        id: { $toString: "$_id" }, // Convert ObjectId to string
+        name: {
+          $ifNull: [
+            { $arrayElemAt: ["$userInfo.profile.name", 0] },
+            { $arrayElemAt: ["$userInfo.email", 0] },
+            "Unknown User",
+          ],
+        },
+        count: 1,
+        _id: 0 // Exclude _id from results
+      } },
+    ]);
+
+    const [sumObservationTime] = await Observation.aggregate([
+      { $sort: { creator: 1, createdAt: 1 } },
+      { $group: { _id: "$creator", createdAtDates: { $push: "$createdAt" } } },
+      { $addFields: {
+        timeDifferences: {
+          $map: {
+            input: { $range: [1, { $size: "$createdAtDates" }] },
+            as: "index",
+            in: {
+              $subtract: [
+                { $arrayElemAt: ["$createdAtDates", "$$index"] },
+                { $arrayElemAt: ["$createdAtDates", { $subtract: ["$$index", 1] }] }
+              ]
+            }
+          }
+        }
+      } },
+      { $unwind: { path: "$timeDifferences" } },
+      { $match: { timeDifferences: { $lt: 3600000 } } },
+      { $group: { _id: null, sumObservation_ms: { $sum: "$timeDifferences" } } },
+      { $project: { _id: 0, overallSum_hours: { $divide: ["$sumObservation_ms", 3600000] } } }
+    ]);
+
+    // Convert ObjectIds in uniqueMediaIdsWithObservations to strings
+    const stringifiedMediaIds = uniqueMediaIdsWithObservations.map(id => id.toString());
+
+    return {
+      totalImages,
+      totalObservations,
+      totalImagesWithObservations: uniqueMediaIdsWithObservations.length,
+      totalValidatedImages: validatedObservations[0]?.count || 0,
+      totalVolunteers: totalVolunteers.length,
+      totalObservationTime: sumObservationTime?.overallSum_hours || 0,
+      uniqueMediaIds: uniqueMediaIdsWithObservations.length,
+      newImages30Days,
+      topCreators: topCreators.map((creator) => ({
+        id: creator.id,
+        name: creator.name || "Unknown User",
+        count: creator.count
+      })),
+      mostActive7Days: mostActive7Days ? {
+        id: mostActive7Days.id,
+        name: mostActive7Days.name,
+        count: mostActive7Days.count
+      } : { id: "", name: "No activity", count: 0 },
+      mostBlanks: mostBlanks ? {
+        id: mostBlanks.id,
+        name: mostBlanks.name,
+        count: mostBlanks.count
+      } : { id: "", name: "No blanks", count: 0 }
+    };
+  } catch (error) {
+    console.error("Error fetching stats:", error);
+    throw new Error("Error fetching statistics");
+  }
 }

--- a/wildmile/app/api/cameratrap/getStats/route.js
+++ b/wildmile/app/api/cameratrap/getStats/route.js
@@ -15,40 +15,8 @@ export async function GET(request) {
     // Get total images
     const totalImages = await CameratrapMedia.countDocuments();
 
-    // Get unique mediaIds in observations aka images with observations
-    const uniqueMediaIdsWithObservations = await Observation.distinct("mediaId");
-
-    // Get total observations
-    const totalObservations = await Observation.countDocuments();
-
-    // Get total images with validated observations
-    const validatedObservations = await Observation.aggregate([
-      {
-        $group: {
-          _id: {
-            mediaId: "$mediaId",
-            scientificName: "$scientificName",
-          },
-          count: { $sum: 1 },
-        },
-      },
-      {
-        $match: {
-          count: { $gte: 2 },
-        },
-      },
-      {
-        $group: {
-          _id: "$_id.mediaId",
-        },
-      },
-      {
-        $count: "count",
-      },
-    ]);
-
-    // Get total number of volunteers that have added at least one observation
-    const totalVolunteers = await Observation.distinct("creator");
+    // Get unique mediaIds in observations
+    const uniqueMediaIds = await Observation.distinct("mediaId");
 
     // Get new images in last 30 days
     const thirtyDaysAgo = new Date();
@@ -57,7 +25,7 @@ export async function GET(request) {
       createdAt: { $gte: thirtyDaysAgo },
     });
 
-    // Get top 5 creators with proper user lookup
+    // Get top 3 creators with proper user lookup
     const topCreators = await Observation.aggregate([
       {
         $group: {
@@ -178,66 +146,9 @@ export async function GET(request) {
       },
     ]);
 
-    // Calculate average observation time in seconds
-    const [sumObservationTime] = await Observation.aggregate([
-      { $sort: { creator: 1, createdAt: 1 } },
-      {
-        $group: {
-          _id: "$creator",
-          createdAtDates: { $push: "$createdAt" }
-        }
-      },
-      {
-        $addFields: {
-          timeDifferences: {
-            $map: {
-              input: { $range: [ 1, { $size: "$createdAtDates" }] },
-              as: "index",
-              in: {
-                $subtract: [
-                  { $arrayElemAt: [ "$createdAtDates", "$$index" ] },
-                  { $arrayElemAt: [ "$createdAtDates", { $subtract: ["$$index", 1] } ] }
-                ]
-              }
-            }
-          }
-        }
-      },
-      { $unwind: { path: "$timeDifferences" } },
-      {
-        $match: {
-          timeDifferences: { $lt: 3600000 } // Less than 1 hour (3600000 ms)
-        }
-      },
-      {
-        $group: {
-          _id: null,
-          "sumObservation_ms": {
-            "$sum": "$timeDifferences"
-          }
-        }
-      },
-      {
-        $project: {
-          _id: 0,
-          overallSum_hours: {
-            $divide: [
-              "$sumObservation_ms",
-              3600000
-            ]
-          }
-        }
-      }
-    ]);
-
     const response = NextResponse.json({
       totalImages,
-      totalObservations,
-      totalImagesWithObservations: uniqueMediaIdsWithObservations.length,
-      totalValidatedImages: validatedObservations[0]?.count || 0,
-      totalVolunteers: totalVolunteers.length,
-      totalObservationTime: sumObservationTime?.overallSum_hours || 0,
-      uniqueMediaIds: uniqueMediaIdsWithObservations.length, // for backwards compatibility
+      uniqueMediaIds: uniqueMediaIds.length,
       newImages30Days,
       topCreators: topCreators.map((creator) => ({
         ...creator,

--- a/wildmile/app/cameratrap/analytics/layout.js
+++ b/wildmile/app/cameratrap/analytics/layout.js
@@ -2,7 +2,6 @@
 import { AppShell, Burger, Group, Title, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import AnalyticsSidebar from "components/analytics/AnalyticsSidebar";
-import AnalyticsStats from "components/analytics/AnalyticsStats";
 import { HeaderNav } from "/components/nav_bar";
 
 export default function AnalyticsLayout({ children }) {

--- a/wildmile/components/analytics/AnalyticsStats.js
+++ b/wildmile/components/analytics/AnalyticsStats.js
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { Grid, Paper, Text, Title } from "@mantine/core";
+import { getStats } from "app/actions/CameratrapActions";
 
 function StatTile({ title, value }) {
   return (
@@ -30,8 +31,7 @@ export default function AnalyticsStats({ page = "overview" }) {
     const fetchStats = async () => {
       try {
         setLoading(true);
-        const res = await fetch("/api/cameratrap/getStats");
-        const data = await res.json();
+        const data = await getStats();
         setStats(data);
       } catch (error) {
         console.error("Failed to fetch stats", error);

--- a/wildmile/components/cameratrap/InfoComponent.js
+++ b/wildmile/components/cameratrap/InfoComponent.js
@@ -12,16 +12,40 @@ import {
   Divider,
 } from "@mantine/core";
 import { UserAvatar } from "/components/shared/UserAvatar";
+// import { getStats } from "/actions/CameratrapActions";
+import { getStats } from "app/actions/CameratrapActions";
 import { Suspense } from "react";
+/**
+ * Server-side data fetch
+ */
+async function fetchStats(force = false) {
+  const url = "/api/cameratrap/getStats";
+
+  // const response = await fetch(url, {
+  //   cache: force ? "no-store" : "force-cache", // or use { next: { revalidate: 60 } }
+  // });
+  const response = await fetch(url);
+  console.log(response);
+  const stats = await response.json();
+  return stats;
+}
 
 /**
  * Server Component
  * Suspense boundaries and error boundaries will come from the parent route usage
  */
 export default async function InfoComponent({ force = false }) {
-  // Server fetch using the API route
-  const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/cameratrap/getStats`);
-  const stats = await response.json();
+  // Server fetch
+  const stats = await getStats();
+
+  // // If stats is null or something else, you can handle it here or let it throw
+  // if (!stats) {
+  //   return (
+  //     <Paper p="md" shadow="xs">
+  //       <Text color="red">Unable to load statistics</Text>
+  //     </Paper>
+  //   );
+  // }
 
   return (
     <Stack spacing="lg">
@@ -53,7 +77,7 @@ export default async function InfoComponent({ force = false }) {
               Images with Observations
             </Text>
             <Text size="xl" weight={700} mt="sm">
-              {stats.totalImagesWithObservations.toLocaleString()}
+              {stats.uniqueMediaIds.toLocaleString()}
             </Text>
           </Card>
         </GridCol>


### PR DESCRIPTION
@nkwsy - I've refactored the added stats to pull from Cameratrap Actions instead of a client side api.

To do this, I rolled back to the last commit you made on the app/api/cameratrap/getStats/route.js file
& the wildmile/components/cameratra/infocomponent.js file - same story for both.

the async function getStats was re-added to the bottom of the CameratrapActions file + the new aggregations.

There are some duplicate requests around total images, thirty days ago, top creators, sevenDaysAgo, and mostBlanks aggregations. These were also there before the changes refactoring all stats out of CameratrapActions previously

My hope is that this resolves the server side duplication error.. though I'm not entirely sure why it was flagging taxonid.

This runs locally on the development and production database, but I cannot test if it will work on vercel.