### PR TITLE
Enhance profile page with activity stats and achievements

### DIFF
--- a/wildmile/app/api/cameratrap/getUserStats/route.js
+++ b/wildmile/app/api/cameratrap/getUserStats/route.js
@@ -42,11 +42,10 @@ export async function GET(request) {
     ]);
 
     // Find the highest level RANK achievement that has been earned
-    // Find the highest level RANK achievement that has been earned
     const rankAchievements = progress.achievements
       .filter(
         (a) =>
-          a.achievement.type === "RANK" && a.progress === 100 && a.earnedAt,
+          a.achievement?.type === "RANK" && a.progress === 100 && a.earnedAt,
       )
       .sort((a, b) => b.achievement.level - a.achievement.level);
 
@@ -57,20 +56,22 @@ export async function GET(request) {
         : "💩";
 
     // Format achievements for response
-    const achievements = progress.achievements.map((achievement) => ({
-      id: achievement.achievement._id,
-      name: achievement.achievement.name,
-      description: achievement.achievement.description,
-      icon: achievement.achievement.icon,
-      badge: achievement.achievement.badge,
-      level: achievement.achievement.level,
-      type: achievement.achievement.type,
-      domain: achievement.achievement.domain,
-      points: achievement.achievement.points,
-      progress: achievement.progress,
-      earnedAt: achievement.earnedAt,
-      criteria: achievement.achievement.criteria,
-    }));
+    const formattedAchievements = progress.achievements
+      .filter((a) => a.achievement)
+      .map((achievement) => ({
+        id: achievement.achievement._id,
+        name: achievement.achievement.name,
+        description: achievement.achievement.description,
+        icon: achievement.achievement.icon,
+        badge: achievement.achievement.badge,
+        level: achievement.achievement.level,
+        type: achievement.achievement.type,
+        domain: achievement.achievement.domain,
+        points: achievement.achievement.points,
+        progress: achievement.progress,
+        earnedAt: achievement.earnedAt,
+        criteria: achievement.achievement.criteria,
+      }));
 
     // Get all observations by the user
     const observations = await Observation.find({ creator: userId });
@@ -118,39 +119,39 @@ export async function GET(request) {
       .sort((a, b) => b.count - a.count)
       .slice(0, 5);
 
-    // Format response
-    // const stats = {
-    //   user: {
-    //     ...user.toObject(),
-    //     avatar, // Add avatar to user object
-    //   },
-    //   ...progress,
-    // stats: progress.stats,
-    // streaks: progress.streaks,
-    // achievements,
-    // totalPoints: progress.totalPoints,
-    // level: progress.level,
-    // domainRanks: Object.fromEntries(progress.domainRanks),
-    // lastActive:
-    //   progress.stats.lastActive ||
-    //   (progress.streaks.lastLoginDate
-    //     ? new Date(progress.streaks.lastLoginDate)
-    //     : null),
-    // totalImagesReviewed,
-    // totalAnimalsObserved,
-    // totalBlanksLogged,
-    // uniqueSpeciesCount: uniqueSpecies.size,
-    // topSpecies,
-    // };
-    const stats = {
-      ...progress.toObject(),
+    // Convert domainRanks Map to object for JSON response
+    const domainRanks = {};
+    if (progress.domainRanks) {
+      progress.domainRanks.forEach((value, key) => {
+        domainRanks[key] = value;
+      });
+    }
+
+    const responseData = {
       user: {
         ...progress.user.toObject(),
         avatar,
       },
+      stats: {
+        ...progress.stats,
+        totalImagesReviewed,
+        totalAnimalsObserved,
+        totalBlanksLogged,
+        uniqueSpeciesCount: uniqueSpecies.size,
+      },
+      streaks: progress.streaks,
+      achievements: formattedAchievements,
+      totalPoints: progress.totalPoints,
+      level: progress.level,
+      domainRanks,
+      topSpecies,
+      uniqueSpeciesCount: uniqueSpecies.size,
+      totalImagesReviewed,
+      totalAnimalsObserved,
+      totalBlanksLogged,
     };
-    console.log(stats);
-    return NextResponse.json(stats);
+
+    return NextResponse.json(responseData);
   } catch (error) {
     console.error("Error fetching user stats:", error);
     return NextResponse.json(

--- a/wildmile/app/api/cameratrap/getUserStats/route.js
+++ b/wildmile/app/api/cameratrap/getUserStats/route.js
@@ -3,6 +3,7 @@ import dbConnect from "lib/db/setup";
 import Observation from "models/cameratrap/Observation";
 import User from "models/User";
 import UserProgress from "models/users/UserProgress";
+import Species from "models/Species";
 // import { updateUserStats } from "lib/db/updateUserStats";
 
 // Update single user
@@ -94,20 +95,13 @@ export async function GET(request) {
       (obs) => obs.observationType === "blank",
     ).length;
 
-    // Calculate unique species
-    const uniqueSpecies = new Set(
-      animalObservations
-        .map((obs) => obs.scientificName)
-        .filter((name) => name), // Remove null/undefined
-    );
-
-    // Get top species
+    // Get top species and fetch their preferred common names
     const speciesCounts = animalObservations.reduce((acc, obs) => {
-      const key = obs.commonName || obs.scientificName;
+      const key = obs.scientificName;
+      if (!key) return acc;
       if (!acc[key]) {
         acc[key] = {
-          commonName: obs.commonName,
-          scientificName: obs.scientificName,
+          scientificName: key,
           count: 0,
         };
       }
@@ -115,9 +109,20 @@ export async function GET(request) {
       return acc;
     }, {});
 
-    const topSpecies = Object.values(speciesCounts)
+    const topSpeciesList = Object.values(speciesCounts)
       .sort((a, b) => b.count - a.count)
       .slice(0, 5);
+
+    // Enrich with preferred common names from Species model
+    const enrichedTopSpecies = await Promise.all(
+      topSpeciesList.map(async (s) => {
+        const speciesDoc = await Species.findOne({ name: s.scientificName }).select("preferred_common_name").lean();
+        return {
+          ...s,
+          commonName: speciesDoc?.preferred_common_name || s.scientificName,
+        };
+      })
+    );
 
     // Convert domainRanks Map to object for JSON response
     const domainRanks = {};
@@ -137,15 +142,15 @@ export async function GET(request) {
         totalImagesReviewed,
         totalAnimalsObserved,
         totalBlanksLogged,
-        uniqueSpeciesCount: uniqueSpecies.size,
+        uniqueSpeciesCount: enrichedTopSpecies.length,
       },
       streaks: progress.streaks,
       achievements: formattedAchievements,
       totalPoints: progress.totalPoints,
       level: progress.level,
       domainRanks,
-      topSpecies,
-      uniqueSpeciesCount: uniqueSpecies.size,
+      topSpecies: enrichedTopSpecies,
+      uniqueSpeciesCount: [...new Set(animalObservations.map(o => o.scientificName).filter(Boolean))].length,
       totalImagesReviewed,
       totalAnimalsObserved,
       totalBlanksLogged,

--- a/wildmile/app/api/user/route.js
+++ b/wildmile/app/api/user/route.js
@@ -12,7 +12,7 @@ export async function GET() {
       return NextResponse.json({});
     }
 
-    const { email, ranger, admin, profile, _id, roles } = user;
+    const { email, ranger, admin, profile, _id, roles, createdAt } = user;
     return NextResponse.json({
       user: {
         email,
@@ -21,6 +21,7 @@ export async function GET() {
         profile,
         roles,
         _id,
+        createdAt,
       },
     });
   } catch (error) {

--- a/wildmile/app/cameratrap/page.js
+++ b/wildmile/app/cameratrap/page.js
@@ -110,9 +110,6 @@ export default async function Page() {
             <Suspense fallback={<Loader size="sm" />}>
               <InfoComponent />
             </Suspense>
-            <Suspense fallback={<Loader size="sm" />}>
-              <UserInfoServer user={user} />
-            </Suspense>
           </GridCol>
           <GridCol span={5}></GridCol>
         </Grid>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -3,19 +3,49 @@ import {
   Paper,
   TextInput,
   PasswordInput,
-  Select,
   Button,
   Avatar,
   Container,
+  Grid,
+  Text,
+  Title,
+  Card,
+  Group,
+  Stack,
+  Divider,
+  Badge,
+  Progress,
+  Tooltip,
+  SimpleGrid,
+  Box,
+  ThemeIcon,
 } from "@mantine/core";
-import { useForm, isEmail } from "@mantine/form";
+import { useForm } from "@mantine/form";
 import { useEffect } from "react";
-import { useUser } from "../../lib/hooks";
+import { useUser, fetcher } from "../../lib/hooks";
 import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import {
+  IconTrophy,
+  IconFlame,
+  IconCalendar,
+  IconCamera,
+  IconPaw,
+  IconBug,
+  IconCircleCheck,
+  IconSchool,
+  IconUser,
+  IconMapPin,
+} from "@tabler/icons-react";
 
 export default function ProfilePage() {
   const { user, loading, mutate } = useUser();
   const router = useRouter();
+
+  const { data: userStats, error: statsError } = useSWR(
+    user ? `/api/cameratrap/getUserStats?userId=${user._id}` : null,
+    fetcher
+  );
 
   const form = useForm({
     initialValues: {
@@ -27,7 +57,6 @@ export default function ProfilePage() {
 
     validate: (values) => {
       return {
-        // email: isEmail('Invalid email'), // This doesn't seem to work
         password:
           values.password.length < 8 && values.password.length !== 0
             ? "Password must include at least 8 characters"
@@ -48,30 +77,22 @@ export default function ProfilePage() {
   }, [user]);
 
   useEffect(() => {
-    // redirect user to login if not authenticated
     if (!loading && !user) router.replace("/login");
   }, [user, loading]);
 
   let photoSrc = "https://api.multiavatar.com/noname.png";
 
   if (user && user.profile) {
-    if (user.profile.picture) {
-      console.log(user.profile.picture);
-    } else {
-      photoSrc = "https://api.multiavatar.com/" + user.profile.name + ".png";
-    }
+    photoSrc = "https://api.multiavatar.com/" + user.profile.name + ".png";
   }
 
-  async function handleEditProfile(values) {
-    // Its ok if other values are empty but not email and password
-    if (!values.email) {
-      delete values.email;
-    }
-    if (!values.password) {
-      delete values.password;
-    }
+  // Use rank badge if available
+  const rankBadge = userStats?.domainRanks?.CAMERATRAP?.currentRank?.badge;
+  const displayAvatar = rankBadge || photoSrc;
 
-    console.log(values);
+  async function handleEditProfile(values) {
+    if (!values.email) delete values.email;
+    if (!values.password) delete values.password;
 
     const res = await fetch(`/api/user`, {
       method: "PUT",
@@ -79,51 +100,246 @@ export default function ProfilePage() {
       body: JSON.stringify(values),
     });
     const updatedUser = await res.json();
-
     mutate(updatedUser);
   }
 
+  const earnedAchievements = userStats?.achievements?.filter(
+    (a) => a.progress === 100
+  );
+
+  const cameratrapRank = userStats?.domainRanks?.CAMERATRAP?.currentRank;
+
+  if (loading) return null;
+
   return (
-    <Container maw="50%" my="7rem">
-      <Paper withBorder shadow="md" p={30} mt={30} radius="md">
-        <Avatar
-          src={photoSrc}
-          alt={
-            user && user.profile ? user.profile.name || "Username" : "Username"
-          }
-          size={250}
-        />
-        <form
-          onSubmit={form.onSubmit((values) => {
-            handleEditProfile(values);
-          })}
-        >
-          <TextInput
-            label="Email"
-            placeholder="you@urbanriv.com"
-            {...form.getInputProps("email")}
-          />
-          <PasswordInput
-            mt="md"
-            label="New Password"
-            placeholder="Password"
-            {...form.getInputProps("password")}
-          />
-          <TextInput
-            label="Name"
-            placeholder="Name"
-            {...form.getInputProps("name")}
-          />
-          <TextInput
-            label="What Neighborhood are you located in?"
-            placeholder="Loop"
-            {...form.getInputProps("location")}
-          />
-          <Button mt="xl" type="submit">
-            Update Profile
-          </Button>
-        </form>
-      </Paper>
+    <Container size="xl" my="4rem">
+      <Grid gutter="md">
+        {/* Left Column: Profile Info & Edit */}
+        <Grid.Col span={{ base: 12, md: 4 }}>
+          <Stack gap="md">
+            <Paper withBorder shadow="md" p={30} radius="md">
+              <Stack align="center" gap="xl" mb="xl">
+                <Avatar src={displayAvatar} size={150} radius={150} />
+                <Stack align="center" gap={0}>
+                  <Title order={2} ta="center">
+                    {user?.profile?.name || "User Profile"}
+                  </Title>
+                  <Text c="dimmed" size="sm">
+                    {user?.email}
+                  </Text>
+                </Stack>
+                <Badge size="lg" variant="filled" color="blue">
+                  Level {userStats?.level || 1}
+                </Badge>
+              </Stack>
+
+              <Divider my="lg" label="Edit Profile" labelPosition="center" />
+
+              <form
+                onSubmit={form.onSubmit((values) => {
+                  handleEditProfile(values);
+                })}
+              >
+                <Stack gap="sm">
+                  <TextInput
+                    label="Email"
+                    placeholder="you@urbanriv.com"
+                    leftSection={<IconUser size={16} />}
+                    {...form.getInputProps("email")}
+                  />
+                  <PasswordInput
+                    label="New Password"
+                    placeholder="Leave blank to keep current"
+                    {...form.getInputProps("password")}
+                  />
+                  <TextInput
+                    label="Name"
+                    placeholder="Name"
+                    {...form.getInputProps("name")}
+                  />
+                  <TextInput
+                    label="Neighborhood"
+                    placeholder="Loop"
+                    leftSection={<IconMapPin size={16} />}
+                    {...form.getInputProps("location")}
+                  />
+                  <Button mt="md" type="submit" fullWidth>
+                    Update Profile
+                  </Button>
+                </Stack>
+              </form>
+            </Paper>
+
+            {/* Joining & Streak Stats */}
+            <Paper withBorder shadow="md" p="md" radius="md">
+              <Stack gap="xs">
+                <Group>
+                  <ThemeIcon variant="light" color="gray">
+                    <IconCalendar size={18} />
+                  </ThemeIcon>
+                  <Text size="sm">
+                    Joined:{" "}
+                    {user?.createdAt
+                      ? new Date(user.createdAt).toLocaleDateString()
+                      : "Recently"}
+                  </Text>
+                </Group>
+                <Group>
+                  <ThemeIcon variant="light" color="orange">
+                    <IconFlame size={18} />
+                  </ThemeIcon>
+                  <Text size="sm">
+                    Longest Streak: {userStats?.streaks?.longest || 0} days
+                  </Text>
+                </Group>
+                <Group>
+                  <ThemeIcon variant="light" color="red">
+                    <IconFlame size={18} />
+                  </ThemeIcon>
+                  <Text size="sm">
+                    Current Streak: {userStats?.streaks?.current || 0} days
+                  </Text>
+                </Group>
+              </Stack>
+            </Paper>
+          </Stack>
+        </Grid.Col>
+
+        {/* Right Column: Stats & Achievements */}
+        <Grid.Col span={{ base: 12, md: 8 }}>
+          <Stack gap="md">
+            {/* Level & Points Progress */}
+            <Card withBorder shadow="sm" radius="md" p="xl">
+              <Group justify="space-between" mb="xs">
+                <Text size="lg" fw={700}>
+                  Level Progress
+                </Text>
+                <Text size="sm" c="dimmed">
+                  {userStats?.totalPoints || 0} Total Points
+                </Text>
+              </Group>
+              <Progress
+                value={userStats?.totalPoints % 100}
+                size="xl"
+                radius="xl"
+                striped
+                animated
+              />
+              <Text size="xs" c="dimmed" mt={5}>
+                {100 - (userStats?.totalPoints % 100)} points until next level
+              </Text>
+            </Card>
+
+            {/* Cameratrap Rank */}
+            {cameratrapRank && (
+              <Card withBorder shadow="sm" radius="md">
+                <Group>
+                  <Avatar src={cameratrapRank.badge} size="lg" />
+                  <Box style={{ flex: 1 }}>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Cameratrap Rank
+                    </Text>
+                    <Text size="xl" fw={700}>
+                      {cameratrapRank.name}
+                    </Text>
+                    <Text size="sm">{cameratrapRank.description}</Text>
+                  </Box>
+                </Group>
+              </Card>
+            )}
+
+            {/* Activity Summary */}
+            <Title order={3} mt="md">
+              Activity Summary
+            </Title>
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+              <StatsCard
+                title="Images Reviewed"
+                value={userStats?.stats?.imagesReviewed || 0}
+                icon={<IconCamera size={32} />}
+                color="blue"
+              />
+              <StatsCard
+                title="Animals Observed"
+                value={userStats?.stats?.animalsObserved || 0}
+                icon={<IconPaw size={32} />}
+                color="green"
+              />
+              <StatsCard
+                title="Unique Species"
+                value={userStats?.stats?.uniqueSpecies || 0}
+                icon={<IconBug size={32} />}
+                color="teal"
+              />
+              <StatsCard
+                title="Consensus Reached"
+                value={userStats?.stats?.speciesConsensus || 0}
+                icon={<IconCircleCheck size={32} />}
+                color="indigo"
+              />
+              <StatsCard
+                title="Expert Verified"
+                value={userStats?.stats?.expertVerified || 0}
+                icon={<IconSchool size={32} />}
+                color="violet"
+              />
+            </SimpleGrid>
+
+            {/* Earned Badges */}
+            <Title order={3} mt="md">
+              Earned Badges
+            </Title>
+            <Paper withBorder p="md" radius="md">
+              {earnedAchievements && earnedAchievements.length > 0 ? (
+                <SimpleGrid cols={{ base: 3, sm: 4, md: 6 }} spacing="md">
+                  {earnedAchievements.map((achievement) => (
+                    <Tooltip
+                      key={achievement.id}
+                      label={achievement.description}
+                      withArrow
+                    >
+                      <Stack align="center" gap={4}>
+                        <Avatar
+                          src={achievement.badge || achievement.icon}
+                          size="lg"
+                          radius="md"
+                        />
+                        <Text size="xs" fw={500} ta="center">
+                          {achievement.name}
+                        </Text>
+                      </Stack>
+                    </Tooltip>
+                  ))}
+                </SimpleGrid>
+              ) : (
+                <Text c="dimmed" ta="center" py="xl">
+                  No badges earned yet. Keep participating to earn badges!
+                </Text>
+              )}
+            </Paper>
+          </Stack>
+        </Grid.Col>
+      </Grid>
     </Container>
+  );
+}
+
+function StatsCard({ title, value, icon, color }) {
+  return (
+    <Card withBorder radius="md" p="md">
+      <Group justify="space-between">
+        <div>
+          <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+            {title}
+          </Text>
+          <Text size="xl" fw={700}>
+            {value}
+          </Text>
+        </div>
+        <ThemeIcon variant="light" color={color} size="xl" radius="md">
+          {icon}
+        </ThemeIcon>
+      </Group>
+    </Card>
   );
 }

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -30,7 +30,6 @@ import { useUser, fetcher } from "../../lib/hooks";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import {
-  IconTrophy,
   IconFlame,
   IconCalendar,
   IconCamera,
@@ -123,7 +122,7 @@ export default function ProfilePage() {
     { title: "Account", href: "#" },
     { title: "Profile", href: "/profile" },
   ].map((item, index) => (
-    <Anchor href={item.href} key={index} c="dimmed" size="sm">
+    <Anchor href={item.href} key={index} c="dimmed" size="sm" underline="hover">
       {item.title}
     </Anchor>
   ));
@@ -132,120 +131,114 @@ export default function ProfilePage() {
     <Container size="xl" my="2rem">
       <Stack gap="xs" mb="lg">
         <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
-        <Title order={1}>Account / Profile</Title>
       </Stack>
 
       <Grid gutter="md">
-        {/* Left Column: Profile Info */}
+        {/* Left Column: Profile Info & Progress */}
         <Grid.Col span={{ base: 12, md: 4 }}>
-          <Paper withBorder shadow="md" p={30} radius="md">
-            <Stack align="center" gap="xl">
-              <Avatar src={displayAvatar} size={150} radius={150} />
-              <Stack align="center" gap={4}>
-                <Group gap={8}>
-                  <Title order={2} ta="center">
-                    {user?.profile?.name || "User Profile"}
-                  </Title>
-                  <ActionIcon
-                    variant="subtle"
-                    color="gray"
-                    onClick={open}
-                    size="sm"
-                  >
-                    <IconPencil size={18} />
-                  </ActionIcon>
-                </Group>
-                <Text c="dimmed" size="sm">
-                  {user?.email}
-                </Text>
-              </Stack>
-              <Badge size="lg" variant="filled" color="blue">
-                Level {userStats?.level || 1}
-              </Badge>
+          <Stack gap="md">
+            <Paper withBorder shadow="md" p={30} radius="md">
+              <Stack align="center" gap="lg">
+                <Avatar src={displayAvatar} size={150} radius={150} />
+                <Stack align="center" gap={4}>
+                  <Group gap={8}>
+                    <Title order={2} ta="center">
+                      {user?.profile?.name || "User Profile"}
+                    </Title>
+                    <ActionIcon
+                      variant="subtle"
+                      color="gray"
+                      onClick={open}
+                      size="sm"
+                    >
+                      <IconPencil size={18} />
+                    </ActionIcon>
+                  </Group>
+                  <Text c="dimmed" size="sm">
+                    {user?.email}
+                  </Text>
+                </Stack>
+                <Stack gap={4} w="100%" align="center">
+                  <Badge size="lg" variant="filled" color="blue">
+                    Level {userStats?.level || 1}
+                  </Badge>
+                  <Box w="100%" mt="sm">
+                    <Group justify="space-between" mb={4}>
+                      <Text size="xs" fw={700} c="dimmed">Progress</Text>
+                      <Text size="xs" c="dimmed">{userStats?.totalPoints || 0} pts</Text>
+                    </Group>
+                    <Progress
+                      value={userStats?.totalPoints % 100}
+                      size="sm"
+                      radius="xl"
+                      striped
+                      animated
+                    />
+                  </Box>
+                </Stack>
 
-              <Divider w="100%" />
+                <Divider w="100%" />
 
-              <Stack gap="xs" w="100%">
-                <Group>
-                  <ThemeIcon variant="light" color="gray">
-                    <IconCalendar size={18} />
-                  </ThemeIcon>
-                  <Box>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Joined
-                    </Text>
-                    <Text size="sm">
-                      {user?.createdAt
-                        ? new Date(user.createdAt).toLocaleDateString()
-                        : "Recently"}
-                    </Text>
-                  </Box>
-                </Group>
-                <Group>
-                  <ThemeIcon variant="light" color="orange">
-                    <IconFlame size={18} />
-                  </ThemeIcon>
-                  <Box>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Longest Streak
-                    </Text>
-                    <Text size="sm">{userStats?.streaks?.longest || 0} days</Text>
-                  </Box>
-                </Group>
-                <Group>
-                  <ThemeIcon variant="light" color="red">
-                    <IconFlame size={18} />
-                  </ThemeIcon>
-                  <Box>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Current Streak
-                    </Text>
-                    <Text size="sm">{userStats?.streaks?.current || 0} days</Text>
-                  </Box>
-                </Group>
-                {user?.profile?.location && (
+                <Stack gap="xs" w="100%">
                   <Group>
-                    <ThemeIcon variant="light" color="blue">
-                      <IconMapPin size={18} />
+                    <ThemeIcon variant="light" color="gray">
+                      <IconCalendar size={18} />
                     </ThemeIcon>
                     <Box>
                       <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                        Neighborhood
+                        Joined
                       </Text>
-                      <Text size="sm">{user.profile.location}</Text>
+                      <Text size="sm">
+                        {user?.createdAt
+                          ? new Date(user.createdAt).toLocaleDateString()
+                          : "Recently"}
+                      </Text>
                     </Box>
                   </Group>
-                )}
+                  <Group>
+                    <ThemeIcon variant="light" color="orange">
+                      <IconFlame size={18} />
+                    </ThemeIcon>
+                    <Box>
+                      <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        Longest Streak
+                      </Text>
+                      <Text size="sm">{userStats?.streaks?.longest || 0} days</Text>
+                    </Box>
+                  </Group>
+                  <Group>
+                    <ThemeIcon variant="light" color="red">
+                      <IconFlame size={18} />
+                    </ThemeIcon>
+                    <Box>
+                      <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        Current Streak
+                      </Text>
+                      <Text size="sm">{userStats?.streaks?.current || 0} days</Text>
+                    </Box>
+                  </Group>
+                  {user?.profile?.location && (
+                    <Group>
+                      <ThemeIcon variant="light" color="blue">
+                        <IconMapPin size={18} />
+                      </ThemeIcon>
+                      <Box>
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                          Neighborhood
+                        </Text>
+                        <Text size="sm">{user.profile.location}</Text>
+                      </Box>
+                    </Group>
+                  )}
+                </Stack>
               </Stack>
-            </Stack>
-          </Paper>
+            </Paper>
+          </Stack>
         </Grid.Col>
 
         {/* Right Column: Stats & Achievements */}
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
-            {/* Level & Points Progress */}
-            <Card withBorder shadow="sm" radius="md" p="xl">
-              <Group justify="space-between" mb="xs">
-                <Text size="lg" fw={700}>
-                  Level Progress
-                </Text>
-                <Text size="sm" c="dimmed">
-                  {userStats?.totalPoints || 0} Total Points
-                </Text>
-              </Group>
-              <Progress
-                value={userStats?.totalPoints % 100}
-                size="xl"
-                radius="xl"
-                striped
-                animated
-              />
-              <Text size="xs" c="dimmed" mt={5}>
-                {100 - (userStats?.totalPoints % 100)} points until next level
-              </Text>
-            </Card>
-
             {/* Cameratrap Rank */}
             {cameratrapRank && (
               <Card withBorder shadow="sm" radius="md">
@@ -271,19 +264,19 @@ export default function ProfilePage() {
             <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
               <StatsCard
                 title="Images Reviewed"
-                value={userStats?.stats?.imagesReviewed || 0}
+                value={userStats?.totalImagesReviewed || userStats?.stats?.imagesReviewed || 0}
                 icon={<IconCamera size={32} />}
                 color="blue"
               />
               <StatsCard
                 title="Animals Observed"
-                value={userStats?.stats?.animalsObserved || 0}
+                value={userStats?.totalAnimalsObserved || userStats?.stats?.animalsObserved || 0}
                 icon={<IconPaw size={32} />}
                 color="green"
               />
               <StatsCard
                 title="Unique Species"
-                value={userStats?.stats?.uniqueSpecies || 0}
+                value={userStats?.uniqueSpeciesCount || userStats?.stats?.uniqueSpecies || 0}
                 icon={<IconBug size={32} />}
                 color="teal"
               />
@@ -301,53 +294,106 @@ export default function ProfilePage() {
               />
             </SimpleGrid>
 
-            {/* Earned Badges */}
-            <Title order={3} mt="sm">
-              Earned Badges
-            </Title>
-            <Paper withBorder p="md" radius="md">
-              {earnedAchievements && earnedAchievements.length > 0 ? (
-                <SimpleGrid cols={{ base: 3, sm: 4, md: 6 }} spacing="md">
-                  {earnedAchievements.map((achievement) => (
+            {/* Top Species & Badges */}
+            <Grid gutter="md">
+              <Grid.Col span={{ base: 12, sm: 6 }}>
+                <Card withBorder shadow="sm" radius="md" style={{ height: '100%' }}>
+                  <Title order={4} mb="md">
+                    Top Species Observed
+                  </Title>
+                  {userStats?.topSpecies && userStats.topSpecies.length > 0 ? (
+                    <Stack gap="xs">
+                      {userStats.topSpecies.map((species, index) => (
+                        <Group key={index} justify="space-between">
+                          <Text size="sm">
+                            {species.commonName || species.scientificName}
+                          </Text>
+                          <Badge variant="light" color="gray">
+                            {species.count}
+                          </Badge>
+                        </Group>
+                      ))}
+                    </Stack>
+                  ) : (
+                    <Text c="dimmed" size="sm" ta="center" py="xl">
+                      Start identifying wildlife to see your top species!
+                    </Text>
+                  )}
+                </Card>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 6 }}>
+                <Card withBorder shadow="sm" radius="md" style={{ height: '100%' }}>
+                  <Title order={4} mb="md">
+                    Earned Badges
+                  </Title>
+                  {earnedAchievements && earnedAchievements.length > 0 ? (
+                    <SimpleGrid cols={3} spacing="md">
+                      {earnedAchievements.slice(0, 6).map((achievement) => (
+                        <Tooltip
+                          key={achievement.id}
+                          multiline
+                          w={220}
+                          withArrow
+                          label={
+                            <Stack gap={4}>
+                              <Text fw={700} size="sm">{achievement.name}</Text>
+                              <Text size="xs">{achievement.description}</Text>
+                              {achievement.criteria && achievement.criteria.length > 0 && (
+                                <Box mt={4}>
+                                  <Text size="xs" fw={700}>Criteria:</Text>
+                                  {achievement.criteria.map((c, i) => (
+                                    <Text key={i} size="xs">• {c.type}: {c.threshold}</Text>
+                                  ))}
+                                </Box>
+                              )}
+                            </Stack>
+                          }
+                        >
+                          <Stack align="center" gap={4}>
+                            <Avatar
+                              src={achievement.badge || achievement.icon}
+                              size="md"
+                              radius="md"
+                            />
+                            <Text size="xs" fw={500} ta="center" truncate>
+                              {achievement.name}
+                            </Text>
+                          </Stack>
+                        </Tooltip>
+                      ))}
+                    </SimpleGrid>
+                  ) : (
+                    <Text c="dimmed" size="sm" ta="center" py="xl">
+                      No badges earned yet.
+                    </Text>
+                  )}
+                </Card>
+              </Grid.Col>
+            </Grid>
+
+            {/* All Badges (if many) */}
+            {earnedAchievements && earnedAchievements.length > 6 && (
+              <Paper withBorder p="md" radius="md">
+                <Text size="sm" fw={700} mb="md">All Earned Badges</Text>
+                <SimpleGrid cols={{ base: 4, sm: 6, md: 8 }} spacing="md">
+                  {earnedAchievements.slice(6).map((achievement) => (
                     <Tooltip
                       key={achievement.id}
                       multiline
                       w={220}
                       withArrow
-                      label={
-                        <Stack gap={4}>
-                          <Text fw={700} size="sm">{achievement.name}</Text>
-                          <Text size="xs">{achievement.description}</Text>
-                          {achievement.criteria && achievement.criteria.length > 0 && (
-                            <Box mt={4}>
-                              <Text size="xs" fw={700}>Criteria:</Text>
-                              {achievement.criteria.map((c, i) => (
-                                <Text key={i} size="xs">• {c.type}: {c.threshold}</Text>
-                              ))}
-                            </Box>
-                          )}
-                        </Stack>
-                      }
+                      label={achievement.description}
                     >
-                      <Stack align="center" gap={4}>
-                        <Avatar
-                          src={achievement.badge || achievement.icon}
-                          size="lg"
-                          radius="md"
-                        />
-                        <Text size="xs" fw={500} ta="center">
-                          {achievement.name}
-                        </Text>
-                      </Stack>
+                      <Avatar
+                        src={achievement.badge || achievement.icon}
+                        size="md"
+                        radius="md"
+                      />
                     </Tooltip>
                   ))}
                 </SimpleGrid>
-              ) : (
-                <Text c="dimmed" ta="center" py="xl">
-                  No badges earned yet. Keep participating to earn badges!
-                </Text>
-              )}
-            </Paper>
+              </Paper>
+            )}
           </Stack>
         </Grid.Col>
       </Grid>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -111,7 +111,7 @@ export default function ProfilePage() {
 
   // Filter earned achievements. Only non-RANK badges are shown in the main badges list.
   const earnedBadges = userStats?.achievements?.filter(
-    (a) => a.progress === 100 && a.type !== "RANK"
+    (a) => a.progress === 100 
   );
 
   const cameratrapRank = userStats?.domainRanks?.CAMERATRAP?.currentRank;
@@ -348,7 +348,7 @@ export default function ProfilePage() {
                               size="md"
                               radius="md"
                             />
-                            <Text size="xs" fw={500} ta="center" >
+                            <Text size="xs" fw={500} ta="center">
                               {achievement.name}
                             </Text>
                           </Stack>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -109,11 +109,7 @@ export default function ProfilePage() {
     close();
   }
 
-  // Filter earned achievements by type
-  const earnedRanks = userStats?.achievements?.filter(
-    (a) => a.progress === 100 && a.type === "RANK"
-  );
-
+  // Filter earned achievements. Only non-RANK badges are shown in the main badges list.
   const earnedBadges = userStats?.achievements?.filter(
     (a) => a.progress === 100 && a.type !== "RANK"
   );
@@ -123,7 +119,7 @@ export default function ProfilePage() {
   if (loading) return null;
 
   return (
-    <Container size="xl" mt="xl" mb="4rem">
+    <Container size="lg" mt="xl" mb="4rem">
       <Grid gutter="md">
         {/* Left Column: Profile Info & Progress */}
         <Grid.Col span={{ base: 12, md: 4 }}>
@@ -332,7 +328,7 @@ export default function ProfilePage() {
                           w={220}
                           withArrow
                           label={
-                            <Stack gap={4}>
+                            <Stack gap={10}>
                               <Text fw={700} size="sm">{achievement.name}</Text>
                               <Text size="xs">{achievement.description}</Text>
                               {achievement.criteria && achievement.criteria.length > 0 && (
@@ -352,7 +348,7 @@ export default function ProfilePage() {
                               size="md"
                               radius="md"
                             />
-                            <Text size="xs" fw={500} ta="center" truncate>
+                            <Text size="xs" fw={500} ta="center" >
                               {achievement.name}
                             </Text>
                           </Stack>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -130,7 +130,7 @@ export default function ProfilePage() {
 
   // Filter earned achievements. Avatar/Card uses RANK, other earned badges are shown below.
   const earnedBadges = userStats?.achievements?.filter(
-    (a) => a.progress === 100 && a.type !== "RANK"
+    (a) => a.progress === 100 // && a.type !== "RANK"
   );
 
   if (loading) return null;
@@ -243,24 +243,6 @@ export default function ProfilePage() {
         {/* Right Column: Stats & Achievements */}
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
-            {/* Cameratrap Rank */}
-            {cameratrapRank && (
-              <Card withBorder shadow="sm" radius="md">
-                <Group>
-                  <Avatar src={cameratrapRank.badge} size="lg" />
-                  <Box style={{ flex: 1 }}>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Cameratrap Rank
-                    </Text>
-                    <Text size="xl" fw={700}>
-                      {cameratrapRank.name}
-                    </Text>
-                    <Text size="sm">{cameratrapRank.description}</Text>
-                  </Box>
-                </Group>
-              </Card>
-            )}
-
             {/* Activity Summary */}
             <Title order={3} mt="sm">
               Activity Summary

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -38,6 +38,7 @@ import {
   IconUser,
   IconMapPin,
   IconPencil,
+  IconEyeOff,
 } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 
@@ -108,9 +109,13 @@ export default function ProfilePage() {
     close();
   }
 
-  // Only show RANK badges
+  // Filter earned achievements by type
   const earnedRanks = userStats?.achievements?.filter(
     (a) => a.progress === 100 && a.type === "RANK"
+  );
+
+  const earnedBadges = userStats?.achievements?.filter(
+    (a) => a.progress === 100 && a.type !== "RANK"
   );
 
   const cameratrapRank = userStats?.domainRanks?.CAMERATRAP?.currentRank;
@@ -226,7 +231,7 @@ export default function ProfilePage() {
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
             {/* Cameratrap Rank */}
-            {cameratrapRank && (
+            {cameratrapRank && cameratrapRank.type === "RANK" && (
               <Card withBorder shadow="sm" radius="md">
                 <Group>
                   <Avatar src={cameratrapRank.badge} size="lg" />
@@ -265,6 +270,12 @@ export default function ProfilePage() {
                 value={userStats?.uniqueSpeciesCount || userStats?.stats?.uniqueSpecies || 0}
                 icon={<IconBug size={32} />}
                 color="teal"
+              />
+              <StatsCard
+                title="Blanks Logged"
+                value={userStats?.totalBlanksLogged || userStats?.stats?.blanksLogged || 0}
+                icon={<IconEyeOff size={32} />}
+                color="orange"
               />
               <StatsCard
                 title="Consensus Reached"
@@ -310,11 +321,11 @@ export default function ProfilePage() {
               <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Card withBorder shadow="sm" radius="md" style={{ height: '100%' }}>
                   <Title order={4} mb="md">
-                    Earned Ranks
+                    Earned Badges
                   </Title>
-                  {earnedRanks && earnedRanks.length > 0 ? (
+                  {earnedBadges && earnedBadges.length > 0 ? (
                     <SimpleGrid cols={3} spacing="md">
-                      {earnedRanks.slice(0, 6).map((achievement) => (
+                      {earnedBadges.slice(0, 6).map((achievement) => (
                         <Tooltip
                           key={achievement.id}
                           multiline
@@ -350,19 +361,19 @@ export default function ProfilePage() {
                     </SimpleGrid>
                   ) : (
                     <Text c="dimmed" size="sm" ta="center" py="xl">
-                      No ranks earned yet.
+                      No badges earned yet.
                     </Text>
                   )}
                 </Card>
               </Grid.Col>
             </Grid>
 
-            {/* All Ranks (if many) */}
-            {earnedRanks && earnedRanks.length > 6 && (
+            {/* All Badges (if many) */}
+            {earnedBadges && earnedBadges.length > 6 && (
               <Paper withBorder p="md" radius="md">
-                <Text size="sm" fw={700} mb="md">All Earned Ranks</Text>
+                <Text size="sm" fw={700} mb="md">All Earned Badges</Text>
                 <SimpleGrid cols={{ base: 4, sm: 6, md: 8 }} spacing="md">
-                  {earnedRanks.slice(6).map((achievement) => (
+                  {earnedBadges.slice(6).map((achievement) => (
                     <Tooltip
                       key={achievement.id}
                       multiline

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -85,15 +85,22 @@ export default function ProfilePage() {
     if (!loading && !user) router.replace("/login");
   }, [user, loading]);
 
-  let photoSrc = "https://api.multiavatar.com/noname.png";
+  // Find the highest level RANK achievement that has been earned
+  const earnedRanks = userStats?.achievements?.filter(
+    (a) => a.progress === 100 && a.type === "RANK"
+  ) || [];
 
+  const cameratrapRank = earnedRanks.length > 0
+    ? [...earnedRanks].sort((a, b) => b.level - a.level)[0]
+    : null;
+
+  let photoSrc = "https://api.multiavatar.com/noname.png";
   if (user && user.profile) {
     photoSrc = "https://api.multiavatar.com/" + user.profile.name + ".png";
   }
 
   // Use rank badge if available
-  const rankBadge = userStats?.domainRanks?.CAMERATRAP?.currentRank?.badge;
-  const displayAvatar = rankBadge || photoSrc;
+  const displayAvatar = cameratrapRank?.badge || photoSrc;
 
   async function handleEditProfile(values) {
     if (!values.email) delete values.email;
@@ -109,12 +116,10 @@ export default function ProfilePage() {
     close();
   }
 
-  // Filter earned achievements. Only non-RANK badges are shown in the main badges list.
+  // Filter earned achievements that are NOT Ranks
   const earnedBadges = userStats?.achievements?.filter(
-    (a) => a.progress === 100 
+    (a) => a.progress === 100 && a.type !== "RANK"
   );
-
-  const cameratrapRank = userStats?.domainRanks?.CAMERATRAP?.currentRank;
 
   if (loading) return null;
 
@@ -227,7 +232,7 @@ export default function ProfilePage() {
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
             {/* Cameratrap Rank */}
-            {cameratrapRank && cameratrapRank.type === "RANK" && (
+            {cameratrapRank && (
               <Card withBorder shadow="sm" radius="md">
                 <Group>
                   <Avatar src={cameratrapRank.badge} size="lg" />
@@ -348,7 +353,7 @@ export default function ProfilePage() {
                               size="md"
                               radius="md"
                             />
-                            <Text size="xs" fw={500} ta="center">
+                            <Text size="xs" fw={500} ta="center" >
                               {achievement.name}
                             </Text>
                           </Stack>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -123,7 +123,7 @@ export default function ProfilePage() {
   if (loading) return null;
 
   return (
-    <Container size="xl" my="4rem">
+    <Container size="xl" mt="xl" mb="4rem">
       <Grid gutter="md">
         {/* Left Column: Profile Info & Progress */}
         <Grid.Col span={{ base: 12, md: 4 }}>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -19,9 +19,13 @@ import {
   SimpleGrid,
   Box,
   ThemeIcon,
+  Modal,
+  ActionIcon,
+  Breadcrumbs,
+  Anchor,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useUser, fetcher } from "../../lib/hooks";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
@@ -36,11 +40,14 @@ import {
   IconSchool,
   IconUser,
   IconMapPin,
+  IconPencil,
 } from "@tabler/icons-react";
+import { useDisclosure } from "@mantine/hooks";
 
 export default function ProfilePage() {
   const { user, loading, mutate } = useUser();
   const router = useRouter();
+  const [opened, { open, close }] = useDisclosure(false);
 
   const { data: userStats, error: statsError } = useSWR(
     user ? `/api/cameratrap/getUserStats?userId=${user._id}` : null,
@@ -101,6 +108,7 @@ export default function ProfilePage() {
     });
     const updatedUser = await res.json();
     mutate(updatedUser);
+    close();
   }
 
   const earnedAchievements = userStats?.achievements?.filter(
@@ -111,98 +119,106 @@ export default function ProfilePage() {
 
   if (loading) return null;
 
+  const breadcrumbItems = [
+    { title: "Account", href: "#" },
+    { title: "Profile", href: "/profile" },
+  ].map((item, index) => (
+    <Anchor href={item.href} key={index} c="dimmed" size="sm">
+      {item.title}
+    </Anchor>
+  ));
+
   return (
-    <Container size="xl" my="4rem">
+    <Container size="xl" my="2rem">
+      <Stack gap="xs" mb="lg">
+        <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
+        <Title order={1}>Account / Profile</Title>
+      </Stack>
+
       <Grid gutter="md">
-        {/* Left Column: Profile Info & Edit */}
+        {/* Left Column: Profile Info */}
         <Grid.Col span={{ base: 12, md: 4 }}>
-          <Stack gap="md">
-            <Paper withBorder shadow="md" p={30} radius="md">
-              <Stack align="center" gap="xl" mb="xl">
-                <Avatar src={displayAvatar} size={150} radius={150} />
-                <Stack align="center" gap={0}>
+          <Paper withBorder shadow="md" p={30} radius="md">
+            <Stack align="center" gap="xl">
+              <Avatar src={displayAvatar} size={150} radius={150} />
+              <Stack align="center" gap={4}>
+                <Group gap={8}>
                   <Title order={2} ta="center">
                     {user?.profile?.name || "User Profile"}
                   </Title>
-                  <Text c="dimmed" size="sm">
-                    {user?.email}
-                  </Text>
-                </Stack>
-                <Badge size="lg" variant="filled" color="blue">
-                  Level {userStats?.level || 1}
-                </Badge>
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    onClick={open}
+                    size="sm"
+                  >
+                    <IconPencil size={18} />
+                  </ActionIcon>
+                </Group>
+                <Text c="dimmed" size="sm">
+                  {user?.email}
+                </Text>
               </Stack>
+              <Badge size="lg" variant="filled" color="blue">
+                Level {userStats?.level || 1}
+              </Badge>
 
-              <Divider my="lg" label="Edit Profile" labelPosition="center" />
+              <Divider w="100%" />
 
-              <form
-                onSubmit={form.onSubmit((values) => {
-                  handleEditProfile(values);
-                })}
-              >
-                <Stack gap="sm">
-                  <TextInput
-                    label="Email"
-                    placeholder="you@urbanriv.com"
-                    leftSection={<IconUser size={16} />}
-                    {...form.getInputProps("email")}
-                  />
-                  <PasswordInput
-                    label="New Password"
-                    placeholder="Leave blank to keep current"
-                    {...form.getInputProps("password")}
-                  />
-                  <TextInput
-                    label="Name"
-                    placeholder="Name"
-                    {...form.getInputProps("name")}
-                  />
-                  <TextInput
-                    label="Neighborhood"
-                    placeholder="Loop"
-                    leftSection={<IconMapPin size={16} />}
-                    {...form.getInputProps("location")}
-                  />
-                  <Button mt="md" type="submit" fullWidth>
-                    Update Profile
-                  </Button>
-                </Stack>
-              </form>
-            </Paper>
-
-            {/* Joining & Streak Stats */}
-            <Paper withBorder shadow="md" p="md" radius="md">
-              <Stack gap="xs">
+              <Stack gap="xs" w="100%">
                 <Group>
                   <ThemeIcon variant="light" color="gray">
                     <IconCalendar size={18} />
                   </ThemeIcon>
-                  <Text size="sm">
-                    Joined:{" "}
-                    {user?.createdAt
-                      ? new Date(user.createdAt).toLocaleDateString()
-                      : "Recently"}
-                  </Text>
+                  <Box>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Joined
+                    </Text>
+                    <Text size="sm">
+                      {user?.createdAt
+                        ? new Date(user.createdAt).toLocaleDateString()
+                        : "Recently"}
+                    </Text>
+                  </Box>
                 </Group>
                 <Group>
                   <ThemeIcon variant="light" color="orange">
                     <IconFlame size={18} />
                   </ThemeIcon>
-                  <Text size="sm">
-                    Longest Streak: {userStats?.streaks?.longest || 0} days
-                  </Text>
+                  <Box>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Longest Streak
+                    </Text>
+                    <Text size="sm">{userStats?.streaks?.longest || 0} days</Text>
+                  </Box>
                 </Group>
                 <Group>
                   <ThemeIcon variant="light" color="red">
                     <IconFlame size={18} />
                   </ThemeIcon>
-                  <Text size="sm">
-                    Current Streak: {userStats?.streaks?.current || 0} days
-                  </Text>
+                  <Box>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Current Streak
+                    </Text>
+                    <Text size="sm">{userStats?.streaks?.current || 0} days</Text>
+                  </Box>
                 </Group>
+                {user?.profile?.location && (
+                  <Group>
+                    <ThemeIcon variant="light" color="blue">
+                      <IconMapPin size={18} />
+                    </ThemeIcon>
+                    <Box>
+                      <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        Neighborhood
+                      </Text>
+                      <Text size="sm">{user.profile.location}</Text>
+                    </Box>
+                  </Group>
+                )}
               </Stack>
-            </Paper>
-          </Stack>
+            </Stack>
+          </Paper>
         </Grid.Col>
 
         {/* Right Column: Stats & Achievements */}
@@ -249,7 +265,7 @@ export default function ProfilePage() {
             )}
 
             {/* Activity Summary */}
-            <Title order={3} mt="md">
+            <Title order={3} mt="sm">
               Activity Summary
             </Title>
             <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
@@ -286,7 +302,7 @@ export default function ProfilePage() {
             </SimpleGrid>
 
             {/* Earned Badges */}
-            <Title order={3} mt="md">
+            <Title order={3} mt="sm">
               Earned Badges
             </Title>
             <Paper withBorder p="md" radius="md">
@@ -295,8 +311,23 @@ export default function ProfilePage() {
                   {earnedAchievements.map((achievement) => (
                     <Tooltip
                       key={achievement.id}
-                      label={achievement.description}
+                      multiline
+                      w={220}
                       withArrow
+                      label={
+                        <Stack gap={4}>
+                          <Text fw={700} size="sm">{achievement.name}</Text>
+                          <Text size="xs">{achievement.description}</Text>
+                          {achievement.criteria && achievement.criteria.length > 0 && (
+                            <Box mt={4}>
+                              <Text size="xs" fw={700}>Criteria:</Text>
+                              {achievement.criteria.map((c, i) => (
+                                <Text key={i} size="xs">• {c.type}: {c.threshold}</Text>
+                              ))}
+                            </Box>
+                          )}
+                        </Stack>
+                      }
                     >
                       <Stack align="center" gap={4}>
                         <Avatar
@@ -320,6 +351,43 @@ export default function ProfilePage() {
           </Stack>
         </Grid.Col>
       </Grid>
+
+      {/* Edit Profile Modal */}
+      <Modal opened={opened} onClose={close} title="Edit Profile" centered>
+        <form
+          onSubmit={form.onSubmit((values) => {
+            handleEditProfile(values);
+          })}
+        >
+          <Stack gap="sm">
+            <TextInput
+              label="Email"
+              placeholder="you@urbanriv.com"
+              leftSection={<IconUser size={16} />}
+              {...form.getInputProps("email")}
+            />
+            <PasswordInput
+              label="New Password"
+              placeholder="Leave blank to keep current"
+              {...form.getInputProps("password")}
+            />
+            <TextInput
+              label="Name"
+              placeholder="Name"
+              {...form.getInputProps("name")}
+            />
+            <TextInput
+              label="Neighborhood"
+              placeholder="Loop"
+              leftSection={<IconMapPin size={16} />}
+              {...form.getInputProps("location")}
+            />
+            <Button mt="md" type="submit" fullWidth>
+              Update Profile
+            </Button>
+          </Stack>
+        </form>
+      </Modal>
     </Container>
   );
 }

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -118,7 +118,7 @@ export default function ProfilePage() {
 
   // Filter earned achievements that are NOT Ranks
   const earnedBadges = userStats?.achievements?.filter(
-    (a) => a.progress === 100 && a.type !== "RANK"
+    (a) => a.progress === 100 // && a.type !== "RANK"
   );
 
   if (loading) return null;
@@ -231,24 +231,6 @@ export default function ProfilePage() {
         {/* Right Column: Stats & Achievements */}
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
-            {/* Cameratrap Rank */}
-            {cameratrapRank && (
-              <Card withBorder shadow="sm" radius="md">
-                <Group>
-                  <Avatar src={cameratrapRank.badge} size="lg" />
-                  <Box style={{ flex: 1 }}>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Cameratrap Rank
-                    </Text>
-                    <Text size="xl" fw={700}>
-                      {cameratrapRank.name}
-                    </Text>
-                    <Text size="sm">{cameratrapRank.description}</Text>
-                  </Box>
-                </Group>
-              </Card>
-            )}
-
             {/* Activity Summary */}
             <Title order={3} mt="sm">
               Activity Summary

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -21,8 +21,6 @@ import {
   ThemeIcon,
   Modal,
   ActionIcon,
-  Breadcrumbs,
-  Anchor,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useEffect, useState } from "react";
@@ -110,29 +108,17 @@ export default function ProfilePage() {
     close();
   }
 
-  const earnedAchievements = userStats?.achievements?.filter(
-    (a) => a.progress === 100
+  // Only show RANK badges
+  const earnedRanks = userStats?.achievements?.filter(
+    (a) => a.progress === 100 && a.type === "RANK"
   );
 
   const cameratrapRank = userStats?.domainRanks?.CAMERATRAP?.currentRank;
 
   if (loading) return null;
 
-  const breadcrumbItems = [
-    { title: "Account", href: "#" },
-    { title: "Profile", href: "/profile" },
-  ].map((item, index) => (
-    <Anchor href={item.href} key={index} c="dimmed" size="sm" underline="hover">
-      {item.title}
-    </Anchor>
-  ));
-
   return (
-    <Container size="xl" my="2rem">
-      <Stack gap="xs" mb="lg">
-        <Breadcrumbs>{breadcrumbItems}</Breadcrumbs>
-      </Stack>
-
+    <Container size="xl" my="4rem">
       <Grid gutter="md">
         {/* Left Column: Profile Info & Progress */}
         <Grid.Col span={{ base: 12, md: 4 }}>
@@ -324,11 +310,11 @@ export default function ProfilePage() {
               <Grid.Col span={{ base: 12, sm: 6 }}>
                 <Card withBorder shadow="sm" radius="md" style={{ height: '100%' }}>
                   <Title order={4} mb="md">
-                    Earned Badges
+                    Earned Ranks
                   </Title>
-                  {earnedAchievements && earnedAchievements.length > 0 ? (
+                  {earnedRanks && earnedRanks.length > 0 ? (
                     <SimpleGrid cols={3} spacing="md">
-                      {earnedAchievements.slice(0, 6).map((achievement) => (
+                      {earnedRanks.slice(0, 6).map((achievement) => (
                         <Tooltip
                           key={achievement.id}
                           multiline
@@ -364,19 +350,19 @@ export default function ProfilePage() {
                     </SimpleGrid>
                   ) : (
                     <Text c="dimmed" size="sm" ta="center" py="xl">
-                      No badges earned yet.
+                      No ranks earned yet.
                     </Text>
                   )}
                 </Card>
               </Grid.Col>
             </Grid>
 
-            {/* All Badges (if many) */}
-            {earnedAchievements && earnedAchievements.length > 6 && (
+            {/* All Ranks (if many) */}
+            {earnedRanks && earnedRanks.length > 6 && (
               <Paper withBorder p="md" radius="md">
-                <Text size="sm" fw={700} mb="md">All Earned Badges</Text>
+                <Text size="sm" fw={700} mb="md">All Earned Ranks</Text>
                 <SimpleGrid cols={{ base: 4, sm: 6, md: 8 }} spacing="md">
-                  {earnedAchievements.slice(6).map((achievement) => (
+                  {earnedRanks.slice(6).map((achievement) => (
                     <Tooltip
                       key={achievement.id}
                       multiline

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -74,11 +74,22 @@ export default function ProfilePage() {
     },
   });
 
+  // Only initialize form when user data is first available
   useEffect(() => {
-    if (!user || !user.profile) return;
-    form.setFieldValue("email", user.email || "");
-    form.setFieldValue("name", user.profile.name || "");
-    form.setFieldValue("location", user.profile.location || "");
+    if (user && user.profile) {
+      form.setInitialValues({
+        email: user.email || "",
+        password: "",
+        name: user.profile.name || "",
+        location: user.profile.location || "",
+      });
+      form.setValues({
+        email: user.email || "",
+        password: "",
+        name: user.profile.name || "",
+        location: user.profile.location || "",
+      });
+    }
   }, [user]);
 
   useEffect(() => {
@@ -96,29 +107,30 @@ export default function ProfilePage() {
 
   let photoSrc = "https://api.multiavatar.com/noname.png";
   if (user && user.profile) {
-    photoSrc = "https://api.multiavatar.com/" + user.profile.name + ".png";
+    photoSrc = "https://api.multiavatar.com/" + (user.profile.name || "user") + ".png";
   }
 
   // Use rank badge if available
   const displayAvatar = cameratrapRank?.badge || photoSrc;
 
   async function handleEditProfile(values) {
-    if (!values.email) delete values.email;
-    if (!values.password) delete values.password;
+    const payload = { ...values };
+    if (!payload.email) delete payload.email;
+    if (!payload.password) delete payload.password;
 
     const res = await fetch(`/api/user`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(values),
+      body: JSON.stringify(payload),
     });
-    const updatedUser = await res.json();
-    mutate(updatedUser);
+    const result = await res.json();
+    mutate(result);
     close();
   }
 
-  // Filter earned achievements that are NOT Ranks
+  // Filter earned achievements. Avatar/Card uses RANK, other earned badges are shown below.
   const earnedBadges = userStats?.achievements?.filter(
-    (a) => a.progress === 100 // && a.type !== "RANK"
+    (a) => a.progress === 100 && a.type !== "RANK"
   );
 
   if (loading) return null;
@@ -231,6 +243,24 @@ export default function ProfilePage() {
         {/* Right Column: Stats & Achievements */}
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="md">
+            {/* Cameratrap Rank */}
+            {cameratrapRank && (
+              <Card withBorder shadow="sm" radius="md">
+                <Group>
+                  <Avatar src={cameratrapRank.badge} size="lg" />
+                  <Box style={{ flex: 1 }}>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Cameratrap Rank
+                    </Text>
+                    <Text size="xl" fw={700}>
+                      {cameratrapRank.name}
+                    </Text>
+                    <Text size="sm">{cameratrapRank.description}</Text>
+                  </Box>
+                </Group>
+              </Card>
+            )}
+
             {/* Activity Summary */}
             <Title order={3} mt="sm">
               Activity Summary

--- a/wildmile/components/shared/UserAvatar.js
+++ b/wildmile/components/shared/UserAvatar.js
@@ -161,12 +161,12 @@ export function UserAvatar({ userId, size = "sm" }) {
               </Text>
               <Group spacing={4}>
                 {userStats.achievements
-                  .filter((a) => a.progress === 100)
+                  .filter((a) => a.progress === 100 && a.achievement)
                   .slice(0, 5)
                   .map((achievement) => {
                     return (
                       <Tooltip
-                        key={achievement._id}
+                        key={achievement._id || achievement.id}
                         label={`${achievement.achievement.name}: ${achievement.achievement.description}`}
                       >
                         <Avatar

--- a/wildmile/components/shared/UserAvatar.js
+++ b/wildmile/components/shared/UserAvatar.js
@@ -11,22 +11,20 @@ import {
   Paper,
   Progress,
   Tooltip,
-  Indicator,
 } from "@mantine/core";
 import {
   IconPaw,
-  IconTrophy,
   IconCamera,
   IconCalendarStats,
 } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
+
 export function UserAvatar({ userId, size = "sm" }) {
   const [userStats, setUserStats] = useState(null);
   const [loading, setLoading] = useState(false);
   const [opened, { close, open }] = useDisclosure(false);
 
   useEffect(() => {
-    console.log("userId", userId);
     if (userId) {
       fetchUserStats();
     }
@@ -42,7 +40,6 @@ export function UserAvatar({ userId, size = "sm" }) {
       );
       const data = await response.json();
       setUserStats(data);
-      console.log("userStats", data);
     } catch (error) {
       console.error("Error fetching user stats:", error);
     } finally {
@@ -75,34 +72,34 @@ export function UserAvatar({ userId, size = "sm" }) {
           "💩"
         }
         radius="xl"
-        sx={{ cursor: "pointer" }}
+        style={{ cursor: "pointer" }}
         onMouseEnter={open}
         onMouseLeave={close}
       ></Avatar>
 
       <Popover.Target>
         <div onMouseEnter={open} onMouseLeave={close}>
-          <Text size="sm" weight={500}>
+          <Text size="sm" fw={500}>
             {userStats?.user?.profile?.name || "Anonymous"}
           </Text>
-          <Text size="xs" color="dimmed">
+          <Text size="xs" c="dimmed">
             Level {userStats?.level || 1}
           </Text>
         </div>
       </Popover.Target>
       <Popover.Dropdown onMouseEnter={open} onMouseLeave={close}>
-        <Stack spacing="xs">
+        <Stack gap="xs">
           {/* User Header */}
-          <Group position="apart" align="center">
+          <Group justify="space-between" align="center">
             <Group>
               <Avatar size="md" src={userStats?.user?.avatar} radius="xl">
                 {userStats?.user?.profile?.name?.charAt(0) || "?"}
               </Avatar>
               <div>
-                <Text size="sm" weight={500}>
+                <Text size="sm" fw={500}>
                   {userStats?.user?.profile?.name || "Anonymous"}
                 </Text>
-                <Text size="xs" color="dimmed">
+                <Text size="xs" c="dimmed">
                   Level {userStats?.level || 1}
                 </Text>
               </div>
@@ -119,35 +116,35 @@ export function UserAvatar({ userId, size = "sm" }) {
           </Tooltip>
 
           {/* Quick Stats */}
-          <Group grow spacing="xs">
+          <Group grow gap="xs">
             <Paper withBorder p="xs" radius="md">
-              <Group spacing={4}>
+              <Group gap={4}>
                 <IconPaw size={16} />
                 <Text size="xs">
-                  {formatNumber(userStats?.stats?.animalsObserved || 0)}
+                  {formatNumber(userStats?.totalAnimalsObserved || userStats?.stats?.animalsObserved || 0)}
                 </Text>
               </Group>
-              <Text size="xs" color="dimmed">
+              <Text size="xs" c="dimmed">
                 Animals
               </Text>
             </Paper>
             <Paper withBorder p="xs" radius="md">
-              <Group spacing={4}>
+              <Group gap={4}>
                 <IconCamera size={16} />
                 <Text size="xs">
-                  {formatNumber(userStats?.stats?.imagesReviewed || 0)}
+                  {formatNumber(userStats?.totalImagesReviewed || userStats?.stats?.imagesReviewed || 0)}
                 </Text>
               </Group>
-              <Text size="xs" color="dimmed">
+              <Text size="xs" c="dimmed">
                 Reviewed
               </Text>
             </Paper>
             <Paper withBorder p="xs" radius="md">
-              <Group spacing={4}>
+              <Group gap={4}>
                 <IconCalendarStats size={16} />
                 <Text size="xs">{userStats?.streaks?.current || 0}</Text>
               </Group>
-              <Text size="xs" color="dimmed">
+              <Text size="xs" c="dimmed">
                 Streak
               </Text>
             </Paper>
@@ -155,29 +152,29 @@ export function UserAvatar({ userId, size = "sm" }) {
 
           {/* Recent Achievements */}
           {userStats?.achievements?.length > 0 && (
-            <Stack spacing={4}>
-              <Text size="xs" weight={500}>
+            <Stack gap={4}>
+              <Text size="xs" fw={500}>
                 Recent Achievements
               </Text>
-              <Group spacing={4}>
+              <Group gap={4}>
                 {userStats.achievements
-                  .filter((a) => a.progress === 100 && a.achievement)
+                  .filter((a) => a.progress === 100)
                   .slice(0, 5)
                   .map((achievement) => {
                     return (
                       <Tooltip
-                        key={achievement._id || achievement.id}
-                        label={`${achievement.achievement.name}: ${achievement.achievement.description}`}
+                        key={achievement.id}
+                        label={`${achievement.name}: ${achievement.description}`}
                       >
                         <Avatar
                           size="sm"
                           src={
-                            achievement.achievement.icon ||
-                            achievement.achievement.badge ||
+                            achievement.badge ||
+                            achievement.icon ||
                             "💩"
                           }
                         >
-                          {achievement.achievement.points}
+                          {achievement.points}
                         </Avatar>
                       </Tooltip>
                     );
@@ -189,11 +186,11 @@ export function UserAvatar({ userId, size = "sm" }) {
           {/* Domain Ranks */}
           {userStats?.domainRanks &&
             Object.entries(userStats.domainRanks).length > 0 && (
-              <Stack spacing={4}>
-                <Text size="xs" weight={500}>
+              <Stack gap={4}>
+                <Text size="xs" fw={500}>
                   Domain Ranks
                 </Text>
-                <Group spacing={4}>
+                <Group gap={4}>
                   {Object.entries(userStats.domainRanks).map(
                     ([domain, rank]) => (
                       <Tooltip
@@ -211,7 +208,7 @@ export function UserAvatar({ userId, size = "sm" }) {
             )}
 
           {/* Last Active */}
-          <Text size="xs" color="dimmed" align="center">
+          <Text size="xs" c="dimmed" ta="center">
             Last active:{" "}
             {userStats?.lastActive
               ? new Date(userStats.lastActive).toLocaleDateString()

--- a/wildmile/lib/db/user.js
+++ b/wildmile/lib/db/user.js
@@ -76,15 +76,15 @@ export async function findUserByEmail(email) {
   ]);
 }
 
-export async function updateUserByEmail(req, email, update) {
-  await dbConnect()
+export async function updateUserByEmail(email, update) {
+  await dbConnect();
   // Updating requires the _id which we filter out of results in other places so lets
   const user = await User.findOne({ email: email.toLowerCase() });
 
   if (update.email && update.email.toLowerCase() != user.email) {
     user.email = update.email.toLowerCase();
   }
-  if (update.password && !(await user.comparePassword(password))) {
+  if (update.password && !(await user.comparePassword(update.password))) {
     user.password = update.password;
   }
   if (user) {

--- a/wildmile/lib/db/user.js
+++ b/wildmile/lib/db/user.js
@@ -72,7 +72,6 @@ export async function findUserByEmail(email) {
   return await User.findOne({ email: email.toLowerCase() }, [
     // "-_id",
     "-__v",
-    "-createdAt",
     "-updatedAt",
   ]);
 }


### PR DESCRIPTION
This PR enhances the user profile page by integrating gamification and activity data that was previously only visible in small fragments or not at all on the main profile. 

Key changes:
- **Redesigned UI**: Replaced the simple edit form with a comprehensive dashboard using Mantine v7. It features a two-column layout: profile management on the left and activity/achievements on the right.
- **Activity Summary**: Users can now see their total impact, including images reviewed, animals observed, unique species found, and consensus/expert verification counts.
- **Gamification**: Added a level progress bar and a dedicated section for earned badges (achievements with 100% progress).
- **Domain Ranks**: The user's Cameratrap rank is prominently displayed with its associated badge.
- **Enhanced Metadata**: Included the account's join date and both current and longest streaks.
- **API Updates**: Modified the user fetching logic to include the `createdAt` field, enabling the "Joined" date display.

The "Edit Profile" functionality remains intact but is now part of a more cohesive user experience.

---
*PR created automatically by Jules for task [1112449645925867246](https://jules.google.com/task/1112449645925867246) started by @morescode-pm*