### PR TITLE
Add video view button to favorite image on landing page

### DIFF
--- a/wildmile/components/cameratrap/ImageAnnotation.js
+++ b/wildmile/components/cameratrap/ImageAnnotation.js
@@ -305,7 +305,11 @@ export function ImageAnnotation({ filters }) {
                   <IconFocus2 />
                 </ActionIcon>
               </Tooltip>
-              <Tooltip label="Play Video">
+              <Tooltip
+                label={
+                  currentImage?.videoUrl ? "Play Video" : "No video available"
+                }
+              >
                 <ActionIcon
                   size="md"
                   onClick={() => setShowVideo(true)}
@@ -480,7 +484,13 @@ export function ImageAnnotation({ filters }) {
         size="lg"
       >
         {currentImage?.videoUrl && (
-          <video src={currentImage.videoUrl} controls autoPlay style={{ width: "100%", maxHeight: "80vh" }}>
+          <video
+            src={currentImage.videoUrl}
+            controls
+            autoPlay
+            muted
+            style={{ width: "100%", maxHeight: "80vh" }}
+          >
             Your browser does not support the video tag.
           </video>
         )}

--- a/wildmile/components/cameratrap/RandomFavorite.js
+++ b/wildmile/components/cameratrap/RandomFavorite.js
@@ -13,6 +13,7 @@ import {
   Group,
   ActionIcon,
   Fieldset,
+  Tooltip,
 } from "@mantine/core";
 import {
   IconRefresh,
@@ -85,23 +86,12 @@ export function RandomFavorite() {
                 className={classes.mainImage}
                 style={{ objectFit: "contain" }}
               />
-              <Group
-                gap="xs"
+              <ActionIcon
                 style={{ position: "absolute", top: 10, right: 10, zIndex: 10 }}
+                onClick={() => setEnlargedImage(true)}
               >
-                {favoriteImage.videoUrl && (
-                  <ActionIcon
-                    color="teal"
-                    variant="filled"
-                    onClick={() => setShowVideo(true)}
-                  >
-                    <IconPlayerPlay size={24} />
-                  </ActionIcon>
-                )}
-                <ActionIcon onClick={() => setEnlargedImage(true)}>
-                  <IconMaximize size={24} />
-                </ActionIcon>
-              </Group>
+                <IconMaximize size={24} />
+              </ActionIcon>
               {/* <Group gap="sm"> */}
               <Flex direction={{ base: "column", sm: "row" }} gap="sm">
                 <Text size="sm" c="dimmed" mt="md" flex="1">
@@ -113,18 +103,35 @@ export function RandomFavorite() {
                     Favorite by: {favoriteImage.favoriteUsers[0].profile.name}
                   </Text>
                 )}
-                <Button
-                  mt="md"
-                  // flex="1"
-                  wrap="wrap"
-                  variant="light"
-                  color="blue"
-                  onClick={fetchRandomFavorite}
-                  loading={loading}
-                  leftSection={<IconArrowsShuffle />}
-                >
-                  New Image
-                </Button>
+                <Group gap="sm" mt="md" wrap="nowrap">
+                  <Tooltip
+                    label={
+                      favoriteImage.videoUrl
+                        ? "Play Video"
+                        : "No video available"
+                    }
+                  >
+                    <ActionIcon
+                      size="md"
+                      color="teal"
+                      variant="outline"
+                      onClick={() => setShowVideo(true)}
+                      disabled={!favoriteImage.videoUrl}
+                    >
+                      <IconPlayerPlay size={22} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Button
+                    flex="1"
+                    variant="light"
+                    color="blue"
+                    onClick={fetchRandomFavorite}
+                    loading={loading}
+                    leftSection={<IconArrowsShuffle />}
+                  >
+                    New Image
+                  </Button>
+                </Group>
               </Flex>
               {/* </Group> */}
             </>
@@ -135,7 +142,7 @@ export function RandomFavorite() {
       <Modal
         opened={showVideo}
         onClose={() => setShowVideo(false)}
-        title="Favorite Video"
+        title="Attached Video"
         size="lg"
       >
         {favoriteImage?.videoUrl && (
@@ -143,6 +150,7 @@ export function RandomFavorite() {
             src={favoriteImage.videoUrl}
             controls
             autoPlay
+            muted
             style={{ width: "100%", maxHeight: "80vh" }}
           >
             Your browser does not support the video tag.

--- a/wildmile/components/cameratrap/RandomFavorite.js
+++ b/wildmile/components/cameratrap/RandomFavorite.js
@@ -18,6 +18,7 @@ import {
   IconRefresh,
   IconMaximize,
   IconArrowsShuffle,
+  IconPlayerPlay,
 } from "@tabler/icons-react";
 import classes from "styles/CameraTrap.module.css";
 import useSWR from "swr";
@@ -31,6 +32,7 @@ const fetcher = async (url) => {
 export function RandomFavorite() {
   const [loading, setLoading] = useState(false);
   const [enlargedImage, setEnlargedImage] = useState(false);
+  const [showVideo, setShowVideo] = useState(false);
 
   const {
     data: favoriteImage,
@@ -83,12 +85,23 @@ export function RandomFavorite() {
                 className={classes.mainImage}
                 style={{ objectFit: "contain" }}
               />
-              <ActionIcon
-                style={{ position: "absolute", top: 10, right: 10 }}
-                onClick={() => setEnlargedImage(true)}
+              <Group
+                gap="xs"
+                style={{ position: "absolute", top: 10, right: 10, zIndex: 10 }}
               >
-                <IconMaximize size={24} />
-              </ActionIcon>
+                {favoriteImage.videoUrl && (
+                  <ActionIcon
+                    color="teal"
+                    variant="filled"
+                    onClick={() => setShowVideo(true)}
+                  >
+                    <IconPlayerPlay size={24} />
+                  </ActionIcon>
+                )}
+                <ActionIcon onClick={() => setEnlargedImage(true)}>
+                  <IconMaximize size={24} />
+                </ActionIcon>
+              </Group>
               {/* <Group gap="sm"> */}
               <Flex direction={{ base: "column", sm: "row" }} gap="sm">
                 <Text size="sm" c="dimmed" mt="md" flex="1">
@@ -118,6 +131,24 @@ export function RandomFavorite() {
           )}
         </div>
       </Fieldset>
+
+      <Modal
+        opened={showVideo}
+        onClose={() => setShowVideo(false)}
+        title="Favorite Video"
+        size="lg"
+      >
+        {favoriteImage?.videoUrl && (
+          <video
+            src={favoriteImage.videoUrl}
+            controls
+            autoPlay
+            style={{ width: "100%", maxHeight: "80vh" }}
+          >
+            Your browser does not support the video tag.
+          </video>
+        )}
+      </Modal>
 
       <Modal
         opened={enlargedImage}


### PR DESCRIPTION
Added a video playback feature to the Random Favorite component on the Camera Trap landing page. When a favorite image includes a `videoUrl`, a play button is now displayed in the top-right corner. Clicking this button opens a modal containing a video player. Verified the UI changes and modal functionality with Playwright.

---
*PR created automatically by Jules for task [7800554471579866315](https://jules.google.com/task/7800554471579866315) started by @morescode-pm*