### PR TITLE
Enhance profile page with labeling history and volunteer stats

### DIFF
--- a/wildmile/app/api/cameratrap/getUserStats/route.js
+++ b/wildmile/app/api/cameratrap/getUserStats/route.js
@@ -4,6 +4,8 @@ import Observation from "models/cameratrap/Observation";
 import User from "models/User";
 import UserProgress from "models/users/UserProgress";
 import Species from "models/Species";
+import CameratrapMedia from "models/cameratrap/Media";
+import mongoose from "mongoose";
 // import { updateUserStats } from "lib/db/updateUserStats";
 
 // Update single user
@@ -132,6 +134,95 @@ export async function GET(request) {
       });
     }
 
+    // Calculate user volunteer hours
+    const userVolunteerHoursResult = await Observation.aggregate([
+      { $match: { creator: new mongoose.Types.ObjectId(userId) } },
+      { $sort: { createdAt: 1 } },
+      {
+        $group: {
+          _id: "$creator",
+          createdAtDates: { $push: "$createdAt" },
+        },
+      },
+      {
+        $addFields: {
+          timeDifferences: {
+            $map: {
+              input: { $range: [1, { $size: "$createdAtDates" }] },
+              as: "index",
+              in: {
+                $subtract: [
+                  { $arrayElemAt: ["$createdAtDates", "$$index"] },
+                  {
+                    $arrayElemAt: [
+                      "$createdAtDates",
+                      { $subtract: ["$$index", 1] },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      { $unwind: { path: "$timeDifferences" } },
+      {
+        $match: {
+          timeDifferences: { $lt: 3600000 }, // Less than 1 hour (3600000 ms)
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          totalHours: {
+            $sum: {
+              $divide: ["$timeDifferences", 3600000], // Convert ms to hours
+            },
+          },
+        },
+      },
+    ]);
+
+    const volunteerHours = userVolunteerHoursResult[0]?.totalHours || 0;
+
+    // Get recent labeling history (6 unique images)
+    const recentHistory = await Observation.aggregate([
+      { $match: { creator: new mongoose.Types.ObjectId(userId) } },
+      { $sort: { createdAt: -1 } },
+      {
+        $group: {
+          _id: "$mediaId",
+          latestObservation: { $first: "$$ROOT" },
+          species: {
+            $addToSet: {
+              scientificName: "$scientificName",
+              commonName: "$commonName",
+              observationType: "$observationType",
+            },
+          },
+        },
+      },
+      { $sort: { "latestObservation.createdAt": -1 } },
+      { $limit: 6 },
+      {
+        $lookup: {
+          from: "cameratrapmedias",
+          localField: "_id",
+          foreignField: "mediaID",
+          as: "media",
+        },
+      },
+      { $unwind: "$media" },
+      {
+        $project: {
+          mediaId: "$_id",
+          publicURL: "$media.publicURL",
+          timestamp: "$latestObservation.createdAt",
+          species: 1,
+        },
+      },
+    ]);
+
     const responseData = {
       user: {
         ...progress.user.toObject(),
@@ -150,10 +241,16 @@ export async function GET(request) {
       level: progress.level,
       domainRanks,
       topSpecies: enrichedTopSpecies,
-      uniqueSpeciesCount: [...new Set(animalObservations.map(o => o.scientificName).filter(Boolean))].length,
+      uniqueSpeciesCount: [
+        ...new Set(
+          animalObservations.map((o) => o.scientificName).filter(Boolean),
+        ),
+      ].length,
       totalImagesReviewed,
       totalAnimalsObserved,
       totalBlanksLogged,
+      volunteerHours,
+      recentHistory,
     };
 
     return NextResponse.json(responseData);

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -410,7 +410,7 @@ export default function ProfilePage() {
                       href={`/cameratrap/identify/${item.mediaId}`}
                       style={{ cursor: "pointer", overflow: "hidden" }}
                     >
-                      <Box style={{ position: "relative", paddingTop: "75%" }}>
+                      <Box style={{ position: "relative", paddingTop: "70%" }}>
                         <img
                           src={item.publicURL}
                           alt="Labeled image"
@@ -419,13 +419,21 @@ export default function ProfilePage() {
                             top: 0,
                             left: 0,
                             width: "100%",
-                            height: "100%",
+                            height: "110%",
                             objectFit: "cover",
                           }}
                         />
                       </Box>
                       <Box p="xs">
-                        <Text size="xs" fw={700} truncate>
+                          <Text
+                            size="xs"
+                            fw={700}
+                            truncate="end"
+                            style={{
+                              lineHeight: "16px",
+                              height: "16px"
+                            }}
+                          >
                           {item.species
                             ?.filter((s) => s.observationType === "animal")
                             .map((s) => s.commonName || s.scientificName)

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -288,60 +288,6 @@ export default function ProfilePage() {
               />
             </SimpleGrid>
 
-            {/* Recent History */}
-            {userStats?.recentHistory && userStats.recentHistory.length > 0 && (
-              <>
-                <Group justify="space-between" mt="lg">
-                  <Title order={3}>Recent Labeling History</Title>
-                  <ThemeIcon variant="light" color="blue" size="lg">
-                    <IconHistory size={20} />
-                  </ThemeIcon>
-                </Group>
-                <SimpleGrid cols={{ base: 2, sm: 3, md: 6 }} spacing="md">
-                  {userStats.recentHistory.map((item) => (
-                    <Card
-                      key={item.mediaId}
-                      withBorder
-                      shadow="sm"
-                      radius="md"
-                      p={0}
-                      component="a"
-                      href={`/cameratrap/identify/${item.mediaId}`}
-                      style={{ cursor: "pointer", overflow: "hidden" }}
-                    >
-                      <Box style={{ position: "relative", paddingTop: "100%" }}>
-                        <img
-                          src={item.publicURL}
-                          alt="Labeled image"
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            height: "100%",
-                            objectFit: "cover",
-                          }}
-                        />
-                      </Box>
-                      <Box p="xs">
-                        <Text size="xs" fw={700} truncate>
-                          {item.species
-                            ?.filter((s) => s.observationType === "animal")
-                            .map((s) => s.commonName || s.scientificName)
-                            .join(", ") ||
-                            item.species?.[0]?.observationType ||
-                            "Blank"}
-                        </Text>
-                        <Text size="10px" c="dimmed">
-                          {new Date(item.timestamp).toLocaleDateString()}
-                        </Text>
-                      </Box>
-                    </Card>
-                  ))}
-                </SimpleGrid>
-              </>
-            )}
-
             {/* Top Species & Badges */}
             <Grid gutter="md">
               <Grid.Col span={{ base: 12, sm: 6 }}>
@@ -441,6 +387,60 @@ export default function ProfilePage() {
                   ))}
                 </SimpleGrid>
               </Paper>
+            )}
+
+            {/* Recent History */}
+            {userStats?.recentHistory && userStats.recentHistory.length > 0 && (
+              <>
+                <Group justify="space-between" mt="lg">
+                  <Title order={3}>Recent Labeling History</Title>
+                  <ThemeIcon variant="light" color="blue" size="lg">
+                    <IconHistory size={20} />
+                  </ThemeIcon>
+                </Group>
+                <SimpleGrid cols={{ base: 2, sm: 3, md: 6 }} spacing="md">
+                  {userStats.recentHistory.map((item) => (
+                    <Card
+                      key={item.mediaId}
+                      withBorder
+                      shadow="sm"
+                      radius="md"
+                      p={0}
+                      component="a"
+                      href={`/cameratrap/identify/${item.mediaId}`}
+                      style={{ cursor: "pointer", overflow: "hidden" }}
+                    >
+                      <Box style={{ position: "relative", paddingTop: "100%" }}>
+                        <img
+                          src={item.publicURL}
+                          alt="Labeled image"
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
+                          }}
+                        />
+                      </Box>
+                      <Box p="xs">
+                        <Text size="xs" fw={700} truncate>
+                          {item.species
+                            ?.filter((s) => s.observationType === "animal")
+                            .map((s) => s.commonName || s.scientificName)
+                            .join(", ") ||
+                            item.species?.[0]?.observationType ||
+                            "Blank"}
+                        </Text>
+                        <Text size="10px" c="dimmed">
+                          {new Date(item.timestamp).toLocaleDateString()}
+                        </Text>
+                      </Box>
+                    </Card>
+                  ))}
+                </SimpleGrid>
+              </>
             )}
           </Stack>
         </Grid.Col>

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -410,7 +410,7 @@ export default function ProfilePage() {
                       href={`/cameratrap/identify/${item.mediaId}`}
                       style={{ cursor: "pointer", overflow: "hidden" }}
                     >
-                      <Box style={{ position: "relative", paddingTop: "100%" }}>
+                      <Box style={{ position: "relative", paddingTop: "75%" }}>
                         <img
                           src={item.publicURL}
                           alt="Labeled image"

--- a/wildmile/app/profile/page.js
+++ b/wildmile/app/profile/page.js
@@ -39,6 +39,8 @@ import {
   IconMapPin,
   IconPencil,
   IconEyeOff,
+  IconClock,
+  IconHistory,
 } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 
@@ -279,12 +281,66 @@ export default function ProfilePage() {
                 color="indigo"
               />
               <StatsCard
-                title="Expert Verified"
-                value={userStats?.stats?.expertVerified || 0}
-                icon={<IconSchool size={32} />}
+                title="Volunteer Hours"
+                value={userStats?.volunteerHours?.toFixed(1) || 0}
+                icon={<IconClock size={32} />}
                 color="violet"
               />
             </SimpleGrid>
+
+            {/* Recent History */}
+            {userStats?.recentHistory && userStats.recentHistory.length > 0 && (
+              <>
+                <Group justify="space-between" mt="lg">
+                  <Title order={3}>Recent Labeling History</Title>
+                  <ThemeIcon variant="light" color="blue" size="lg">
+                    <IconHistory size={20} />
+                  </ThemeIcon>
+                </Group>
+                <SimpleGrid cols={{ base: 2, sm: 3, md: 6 }} spacing="md">
+                  {userStats.recentHistory.map((item) => (
+                    <Card
+                      key={item.mediaId}
+                      withBorder
+                      shadow="sm"
+                      radius="md"
+                      p={0}
+                      component="a"
+                      href={`/cameratrap/identify/${item.mediaId}`}
+                      style={{ cursor: "pointer", overflow: "hidden" }}
+                    >
+                      <Box style={{ position: "relative", paddingTop: "100%" }}>
+                        <img
+                          src={item.publicURL}
+                          alt="Labeled image"
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
+                          }}
+                        />
+                      </Box>
+                      <Box p="xs">
+                        <Text size="xs" fw={700} truncate>
+                          {item.species
+                            ?.filter((s) => s.observationType === "animal")
+                            .map((s) => s.commonName || s.scientificName)
+                            .join(", ") ||
+                            item.species?.[0]?.observationType ||
+                            "Blank"}
+                        </Text>
+                        <Text size="10px" c="dimmed">
+                          {new Date(item.timestamp).toLocaleDateString()}
+                        </Text>
+                      </Box>
+                    </Card>
+                  ))}
+                </SimpleGrid>
+              </>
+            )}
 
             {/* Top Species & Badges */}
             <Grid gutter="md">

--- a/wildmile/components/cameratrap/CameraTrapTutorial.js
+++ b/wildmile/components/cameratrap/CameraTrapTutorial.js
@@ -1,10 +1,12 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Joyride, STATUS } from 'react-joyride';
-import { useTutorial } from './ContextCamera';
+import { useTutorial, useReviewMode, useRelabeling } from './ContextCamera';
 import { useUser } from 'lib/hooks';
 
 export const CameraTrapTutorial = () => {
   const [run, setRun] = useTutorial();
+  const [reviewMode] = useReviewMode();
+  const [isRelabeling] = useRelabeling();
   const { user } = useUser();
   const [ready, setReady] = useState(false);
 
@@ -57,7 +59,33 @@ export const CameraTrapTutorial = () => {
       placement: 'top',
       skipBeacon: true,
     },
-  ], [user]);
+    {
+      target: '#review-mode-toggle',
+      content: 'Once you are comfortable with identification, try Review Mode! It lets you quickly confirm or correct the community consensus.',
+      placement: 'bottom',
+      skipBeacon: true,
+    },
+    ...(reviewMode && !isRelabeling ? [
+      {
+        target: '#review-mode-controls',
+        content: 'In Review Mode, we show you what others have observed. Your job is to verify if this matches what you see.',
+        placement: 'left',
+        skipBeacon: true,
+      },
+      {
+        target: '#confirm-button',
+        content: 'If the list is correct, click "Confirm". This helps us reach consensus faster!',
+        placement: 'top',
+        skipBeacon: true,
+      },
+      {
+        target: '#relabel-button',
+        content: 'If something is missing or incorrect, click "Re-label" to enter the standard identification mode and provide your own labels.',
+        placement: 'top',
+        skipBeacon: true,
+      },
+    ] : []),
+  ], [user, reviewMode, isRelabeling]);
 
   useEffect(() => {
     let timeoutId;

--- a/wildmile/components/cameratrap/ImageAnnotationPage.js
+++ b/wildmile/components/cameratrap/ImageAnnotationPage.js
@@ -83,10 +83,13 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
 
   // Effect for initializing page: fetch deployments, then defaults, then initial image
   useEffect(() => {
+    let isMounted = true;
     const initializePage = async () => {
       setPageLoading(true);
       await fetchDeployments(); // Fetch deployments first
       const currentInitialFilters = await fetchFilterDefaults(); // Then fetch defaults
+
+      if (!isMounted) return;
       setAppliedFilters(currentInitialFilters); // Set state after fetching
 
       if (initialImageId) {
@@ -97,8 +100,12 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
       setPageLoading(false);
     };
     initializePage();
+
+    return () => {
+      isMounted = false;
+    };
     // Adding initialImageId and fetchFilterDefaults to dependencies.
-  }, [initialImageId, fetchFilterDefaults]); // Removed reviewMode from here to prevent re-fetch on mode toggle
+  }, [initialImageId]); // Removed fetchFilterDefaults to prevent re-fetch
 
   const { user, loading: userLoading } = useUser();
 
@@ -297,6 +304,7 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
                   variant="light"
                   color="blue"
                   size="sm"
+                  id="review-mode-toggle"
                   leftSection={<IconEye size={18} />}
                   onClick={() => {
                     setReviewMode(true);

--- a/wildmile/components/cameratrap/ObservationTally.js
+++ b/wildmile/components/cameratrap/ObservationTally.js
@@ -218,8 +218,8 @@ export function ObservationTally({ fetchNextImage }) {
           setSelection([]);
           setAnimalCounts({});
         }
-        setRelabeling(false);
         await fetchNextImage();
+        setRelabeling(false);
       } else {
         alert("Failed to save observations.");
       }

--- a/wildmile/components/cameratrap/ReviewControls.js
+++ b/wildmile/components/cameratrap/ReviewControls.js
@@ -265,6 +265,7 @@ export const ReviewControls = ({ fetchNextImage }) => {
       {/* Main Review Card */}
       {currentImage && !showLoading && (
         <div
+          id="review-mode-controls"
           style={{
             width: "100%",
             zIndex: 1
@@ -287,6 +288,7 @@ export const ReviewControls = ({ fetchNextImage }) => {
               <Group justify="space-between" mt="md" style={{ width: "100%" }}>
                 <Tooltip label="Re-label">
                   <Button
+                    id="relabel-button"
                     variant="light"
                     color="red"
                     radius="xl"
@@ -300,6 +302,7 @@ export const ReviewControls = ({ fetchNextImage }) => {
 
                 <Tooltip label="Confirm">
                   <Button
+                    id="confirm-button"
                     variant="filled"
                     color="green"
                     radius="xl"


### PR DESCRIPTION
This change enhances the user profile page with a new 'Recent Labeling History' section, allowing volunteers to review their previous identifications. It also replaces the 'Expert Verified' stat with a 'Volunteer Hours' estimate based on active labeling sessions. Additionally, it fixes a bug in the camera trap labeling interface where the previous image's consensus would briefly flash when saving a re-labeled observation in Review Mode.

---
*PR created automatically by Jules for task [5694435161929447286](https://jules.google.com/task/5694435161929447286) started by @morescode-pm*