### PR TITLE
Allow Closing Tutorial on Click Out / Skip / Close and Reset on Restart

### DIFF
--- a/wildmile/components/cameratrap/CameraTrapTutorial.js
+++ b/wildmile/components/cameratrap/CameraTrapTutorial.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Joyride, STATUS } from 'react-joyride';
+import { Joyride, STATUS, ACTIONS } from 'react-joyride';
 import { useTutorial } from './ContextCamera';
 
 const steps = [
@@ -52,7 +52,10 @@ export const CameraTrapTutorial = () => {
   const handleJoyrideCallback = (data) => {
     const { status, type, index, action } = data;
 
-    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+    if (
+      [STATUS.FINISHED, STATUS.SKIPPED].includes(status) ||
+      [ACTIONS.CLOSE, ACTIONS.SKIP].includes(action)
+    ) {
       setRun(0);
     }
   };
@@ -68,6 +71,7 @@ export const CameraTrapTutorial = () => {
       scrollOffset={100}
       disableScrolling={false}
       callback={handleJoyrideCallback}
+      disableOverlayClose={false}
       styles={{
         options: {
           primaryColor: '#40c057', // Green

--- a/wildmile/components/cameratrap/CameraTrapTutorial.js
+++ b/wildmile/components/cameratrap/CameraTrapTutorial.js
@@ -50,11 +50,12 @@ export const CameraTrapTutorial = () => {
   const [run, setRun] = useTutorial();
 
   const handleJoyrideCallback = (data) => {
-    const { status, type, index, action } = data;
+    const { status, type, index, action, origin } = data;
 
     if (
       [STATUS.FINISHED, STATUS.SKIPPED].includes(status) ||
-      [ACTIONS.CLOSE, ACTIONS.SKIP].includes(action)
+      [ACTIONS.CLOSE, ACTIONS.SKIP].includes(action) ||
+      ['overlay', 'keyboard', 'button_close', 'button_skip'].includes(origin)
     ) {
       setRun(0);
     }

--- a/wildmile/components/cameratrap/CameraTrapTutorial.js
+++ b/wildmile/components/cameratrap/CameraTrapTutorial.js
@@ -87,9 +87,16 @@ export const CameraTrapTutorial = () => {
       scrollOffset={100}
       disableScrolling={false}
       callback={handleJoyrideCallback}
+      onEvent={handleJoyrideCallback}
       disableOverlayClose={false}
       disableBeacon={true}
       skipBeacon={true}
+      options={{
+        overlayClickAction: 'close',
+        dismissKeyAction: 'close',
+        closeButtonAction: 'skip',
+        skipBeacon: true,
+      }}
       styles={{
         options: {
           primaryColor: '#40c057', // Green

--- a/wildmile/components/cameratrap/CameraTrapTutorial.js
+++ b/wildmile/components/cameratrap/CameraTrapTutorial.js
@@ -8,41 +8,56 @@ const steps = [
     content: '1. Use these controls to navigate images. You can go to the next/previous photo with the arrows, jump to the earliest image, or click "Get Images" to refresh. You can also adjust your filters here.',
     placement: 'bottom',
     disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#image-annotation-card',
     content: '2. You can zoom in and out of the image using your mouse wheel or pinch gestures to see details more clearly.',
     placement: 'right',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#image-action-buttons',
     content: '3. Use these buttons to interact with the image: copy a share link, view AI detections, play a video, request ID help, report issues, or favorite the image.',
     placement: 'top',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#save-observations-button',
     content: '4. If no animals are visible, click "No Animals Visible". Also, check the Human or Vehicle boxes if they are present in the photo.',
     placement: 'left',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#wildlife-search-container',
     content: '5. If animals are present, select them from the available species in this sidebar. Tip: Select one now for step 7 to make sense',
     placement: 'left',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#species-tabs',
     content: '6. Use the clock icon for "Recently Used" species and the user icon for "My Animals". You can also search for a specific animal. If you need help, post to our WhatsApp channel!',
     placement: 'left',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#observation-tally-container',
     content: '7. Once you select animals, they will appear here. Use the plus and minus buttons to set the count for each type visible in the photo.',
     placement: 'left',
+    disableBeacon: true,
+    skipBeacon: true,
   },
   {
     target: '#save-observations-button',
     content: '8. Finally, click "Save Observations" (log in or sign up first!). Your selections are kept between images to help with photo bursts, so remember to remove any animals that aren\'t in the next photo!',
     placement: 'top',
+    disableBeacon: true,
+    skipBeacon: true,
   },
 ];
 
@@ -73,6 +88,8 @@ export const CameraTrapTutorial = () => {
       disableScrolling={false}
       callback={handleJoyrideCallback}
       disableOverlayClose={false}
+      disableBeacon={true}
+      skipBeacon={true}
       styles={{
         options: {
           primaryColor: '#40c057', // Green


### PR DESCRIPTION
Updates CameraTrapTutorial.js to use disableOverlayClose={false} on react-joyride and updates the handleJoyrideCallback function to set the run/tutorial state back to 0 on skip/close actions or finished/skipped statuses, ensuring the tutorial ends and resets back to the first step on subsequent help clicks.

---
*PR created automatically by Jules for task [4746437934418295972](https://jules.google.com/task/4746437934418295972) started by @morescode-pm*